### PR TITLE
fix: disable helmet COOP to allow Google Sign-In popup

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -103,6 +103,7 @@ const PORT = process.env.PORT || 3001;
 app.use(helmet({
   contentSecurityPolicy: false,      // Vite-built React app uses inline scripts; custom CSP TBD
   crossOriginEmbedderPolicy: false,  // Firebase SDK + Google Sign-In load from CDN
+  crossOriginOpenerPolicy: false,    // Google Sign-In uses signInWithPopup (cross-origin window.open)
 }));
 app.use(cors({
   origin: [


### PR DESCRIPTION
## Summary
- Disable helmet's `crossOriginOpenerPolicy` header which blocks `signInWithPopup`
- COOP `same-origin` prevents the Google auth popup from communicating back to the opener window

## Test plan
- [x] 220 vitest tests pass
- [x] Login flow works (popup can communicate auth result back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)