### PR TITLE
fix: disable helmet CORP blocking cross-origin resources

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -101,9 +101,10 @@ const app = express();
 const PORT = process.env.PORT || 3001;
 
 app.use(helmet({
-  contentSecurityPolicy: false,      // Vite-built React app uses inline scripts; custom CSP TBD
-  crossOriginEmbedderPolicy: false,  // Firebase SDK + Google Sign-In load from CDN
-  crossOriginOpenerPolicy: false,    // Google Sign-In uses signInWithPopup (cross-origin window.open)
+  contentSecurityPolicy: false,       // Vite-built React app uses inline scripts; custom CSP TBD
+  crossOriginEmbedderPolicy: false,   // Firebase SDK + Google Sign-In load from CDN
+  crossOriginOpenerPolicy: false,     // Google Sign-In uses signInWithPopup (cross-origin window.open)
+  crossOriginResourcePolicy: false,   // Firebase JS SDK loaded from cross-origin CDN
 }));
 app.use(cors({
   origin: [


### PR DESCRIPTION
## Summary
- Disable helmet's `crossOriginResourcePolicy` header (`same-origin` by default)
- This header blocks Firebase SDK, Google Fonts, and other CDN resources from loading

Follows up on #21 which fixed COOP but missed CORP.

## Test plan
- [x] Verify Firebase SDK loads in browser
- [x] Google Sign-In popup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)