### PR TITLE
fix: health check GCS probe + error logging

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -216,7 +216,8 @@ app.get('/api/health', async (req, res) => {
       const firestore = getFirestore();
       await firestore.listCollections();
       checks.firestore = true;
-    } catch {
+    } catch (err) {
+      console.error('[Health] Firestore check failed:', err.message);
       checks.firestore = false;
     }
   }
@@ -224,9 +225,10 @@ app.get('/api/health', async (req, res) => {
   // Verify GCS connectivity in production
   if (!IS_LOCAL && bucket) {
     try {
-      await bucket.getMetadata();
+      await bucket.getFiles({ maxResults: 1 });
       checks.gcsConnected = true;
-    } catch {
+    } catch (err) {
+      console.error('[Health] GCS check failed:', err.message);
       checks.gcsConnected = false;
     }
   }


### PR DESCRIPTION
## Summary
- Replace `bucket.getMetadata()` with `bucket.getFiles({ maxResults: 1 })` in the health check — the service account has `storage.objectAdmin` but not `storage.buckets.get`, so the old probe always failed despite GCS working fine
- Add `console.error` logging to both Firestore and GCS catch blocks for future debugging

**Context:** Also created the missing Firestore `(default)` database in the `russian-transcription` GCP project and deployed security rules. The health endpoint was returning `degraded` because (1) no Firestore database existed and (2) the GCS probe needed bucket-level permissions the service account doesn't have.

## Test plan
- [ ] All unit tests pass (592 total)
- [ ] All E2E tests pass
- [ ] Lint clean
- [ ] After deploy, `GET /api/health` returns `{"status": "ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)