### PR TITLE
fix(deploy): correct GCP project in build-base.sh

### DIFF
--- a/build-base.sh
+++ b/build-base.sh
@@ -6,6 +6,6 @@ set -e
 
 echo "Building base image with Cloud Build..."
 cd server
-gcloud builds submit --tag gcr.io/book-friend-finder/russian-base:latest --dockerfile Dockerfile.base
+gcloud builds submit --tag gcr.io/russian-transcription/russian-base:latest --dockerfile Dockerfile.base
 
 echo "Done! Base image updated."


### PR DESCRIPTION
## Summary
- `build-base.sh` was targeting `gcr.io/book-friend-finder/` but `Dockerfile` expects `gcr.io/russian-transcription/` — causing deploy failures
- Base image has been rebuilt and pushed to the correct project

## Test plan
- [x] Base image pushed to `gcr.io/russian-transcription/russian-base:latest` and verified with `gcloud container images list-tags`
- [ ] CI deploy should pass on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)