### PR TITLE
fix(deck): sync enrichment at card-add time + server-side cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ Express.js on port 3001 (local) / `PORT` env var (Cloud Run). Key files:
 - `storage/url-cache.js` — URL→session mapping (6h TTL, per-user): `getCachedSession`, `cacheSessionUrl`
 - `storage/extraction-cache.js` — yt-dlp info cache in GCS (2h TTL): `getCachedExtraction`, `cacheExtraction`
 - `storage/translation-cache.js` — Translation LRU cache (max 10K entries)
+- `storage/example-cache.js` — Example sentence LRU cache (max 10K entries, keyed by lowercase word)
 - `storage/session-repository.js` — Session CRUD, LRU memory cache (50), GCS persistence, cleanup, URL cache rebuild
 - `progress.js` — SSE client management (`progressClients` Map), `sendProgress()`/`createProgressCallback()` helpers, terminal progress rendering
 - `chunking.js` — Splits transcripts at natural pauses (>0.5s gaps), targets ~3min chunks
@@ -261,7 +262,7 @@ Express.js on port 3001 (local) / `PORT` env var (Cloud Run). Key files:
 
 Layered architecture: `useDeck` (orchestrator) → `deck-persistence` (IO) + `deck-enrichment` (API) + `sm2` (algorithm) + `russian` (shared utils). See `CLAUDE_DOCS/deck-architecture.md` for full details.
 
-- `src/hooks/useDeck.ts` — Thin orchestrator: React state, card CRUD, coordinates persistence and enrichment. Fire-and-forget example generation on `addCard`.
+- `src/hooks/useDeck.ts` — Thin orchestrator: React state, card CRUD, coordinates persistence and enrichment. Awaits example generation on `addCard` (card enters state already enriched).
 - `src/services/deck-persistence.ts` — Firestore load/save (debounced 500ms), localStorage fallback/migration. Accepts `userId` from `useAuth`.
 - `src/services/deck-enrichment.ts` — Batch dictionary lookup (`/api/enrich-deck`), batch example generation (`/api/generate-examples`), single-card example at add time. All errors reported to Sentry.
 - `src/utils/sm2.ts` — SM-2 spaced repetition algorithm with Anki-like learning steps (1min/5min) and graduated review intervals. Ease factor only updated during review phase (not learning).

--- a/CLAUDE_DOCS/deck-architecture.md
+++ b/CLAUDE_DOCS/deck-architecture.md
@@ -26,7 +26,7 @@ App.tsx
 
 ### Key Design Decisions
 
-1. **WordPopup is pure presentation** — clicking "Add to deck" synchronously calls `onAddToDeck`. Example sentence generation happens asynchronously in `useDeck` via fire-and-forget `enrichSingleCardExample()`.
+1. **WordPopup shows enrichment progress** — clicking "Add to deck" triggers an async `onAddToDeck` that awaits `enrichSingleCardExample()` before adding the card to state. WordPopup shows an "Adding..." spinner during this ~1-2s wait. This ensures the card enters state already enriched with an example sentence, avoiding stale-snapshot bugs in ReviewPanel. Server-side LRU cache (`exampleCache`, 10K entries) makes repeat words instant.
 
 2. **SM-2 ease factor only changes during review phase** — learning phase (repetition === 0) uses fixed intervals without modifying EF. This prevents new cards from being penalized by early struggles.
 

--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,7 @@ import helmet from 'helmet';
 import * as Sentry from '@sentry/node';
 import { createChunks, createTextChunks, getChunkTranscript, formatTime } from './chunking.js';
 import {
-  localSessions, analysisSessions, urlSessionCache, translationCache,
+  localSessions, analysisSessions, urlSessionCache, translationCache, exampleCache,
   getSignedMediaUrl, getCachedExtraction, cacheExtraction,
   getCachedSession, cacheSessionUrl,
   getAnalysisSession, setAnalysisSession,
@@ -479,39 +479,61 @@ app.post('/api/generate-examples', requireSubscription, requireBudget, async (re
   }
 
   try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        messages: [{
-          role: 'system',
-          content: 'You are a Russian language tutor. For each Russian word provided, generate one simple example sentence at A2-B1 level (5-12 words). Use the word in a natural inflected form. Return a JSON object mapping each word to { "russian": "<sentence>", "english": "<translation>" }.',
-        }, {
-          role: 'user',
-          content: words.join('\n'),
-        }],
-        response_format: { type: 'json_object' },
-        temperature: 0.7,
-      }),
-    });
-
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.error?.message || 'Example generation failed');
+    // Check cache for each word — only call GPT for uncached words
+    const cached = {};
+    const uncached = [];
+    for (const w of words) {
+      const key = w.toLowerCase();
+      const hit = exampleCache.get(key);
+      if (hit) {
+        cached[w] = hit;
+      } else {
+        uncached.push(w);
+      }
     }
 
-    const data = await response.json();
-    let examples;
-    try {
-      examples = JSON.parse(data.choices[0].message.content);
-    } catch {
-      throw new Error('GPT returned invalid JSON for example sentences');
+    let freshExamples = {};
+    if (uncached.length > 0) {
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          messages: [{
+            role: 'system',
+            content: 'You are a Russian language tutor. For each Russian word provided, generate one simple example sentence at A2-B1 level (5-12 words). Use the word in a natural inflected form. Return a JSON object mapping each word to { "russian": "<sentence>", "english": "<translation>" }.',
+          }, {
+            role: 'user',
+            content: uncached.join('\n'),
+          }],
+          response_format: { type: 'json_object' },
+          temperature: 0.7,
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error?.message || 'Example generation failed');
+      }
+
+      const data = await response.json();
+      try {
+        freshExamples = JSON.parse(data.choices[0].message.content);
+      } catch {
+        throw new Error('GPT returned invalid JSON for example sentences');
+      }
+      trackCost(req.uid, costs.gpt4oMini());
+
+      // Cache fresh results
+      for (const [word, example] of Object.entries(freshExamples)) {
+        if (example) exampleCache.set(word.toLowerCase(), example);
+      }
     }
-    trackCost(req.uid, costs.gpt4oMini());
+
+    const examples = { ...cached, ...freshExamples };
     res.json({ examples });
   } catch (error) {
     console.error('[GenerateExamples] Error:', error);

--- a/server/session-store.js
+++ b/server/session-store.js
@@ -13,6 +13,7 @@ export { extractVideoId, normalizeUrl } from './storage/url-utils.js';
 export { urlSessionCache, cacheSessionUrl } from './storage/url-cache.js';
 export { getCachedExtraction, cacheExtraction } from './storage/extraction-cache.js';
 export { translationCache } from './storage/translation-cache.js';
+export { exampleCache } from './storage/example-cache.js';
 
 // Session CRUD
 export {

--- a/server/storage/example-cache.js
+++ b/server/storage/example-cache.js
@@ -1,0 +1,8 @@
+/**
+ * Example sentence LRU cache.
+ * Keyed by lowercase word, values are { russian, english } sentence pairs.
+ * Bounded to prevent unbounded memory growth.
+ */
+import { LRUCache } from 'lru-cache';
+
+export const exampleCache = new LRUCache({ max: 10000 });

--- a/src/components/TranscriptPanel.tsx
+++ b/src/components/TranscriptPanel.tsx
@@ -10,7 +10,7 @@ interface TranscriptPanelProps {
   config: TranslatorConfig;
   wordFrequencies?: Map<string, number>;
   isLoading?: boolean;
-  onAddToDeck?: (word: string, translation: string, sourceLanguage: string, dictionary?: DictionaryEntry) => void;
+  onAddToDeck?: (word: string, translation: string, sourceLanguage: string, dictionary?: DictionaryEntry) => void | Promise<void>;
   isWordInDeck?: (word: string) => boolean;
 }
 

--- a/src/components/WordPopup.tsx
+++ b/src/components/WordPopup.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import type { Translation, DictionaryEntry } from '../types';
 import { speak } from '../utils/russian';
 
@@ -8,7 +8,7 @@ interface WordPopupProps {
   error: string | null;
   position: { x: number; y: number } | null;
   onClose: () => void;
-  onAddToDeck?: (word: string, translation: string, sourceLanguage: string, dictionary?: DictionaryEntry) => void;
+  onAddToDeck?: (word: string, translation: string, sourceLanguage: string, dictionary?: DictionaryEntry) => void | Promise<void>;
   isInDeck?: boolean;
 }
 
@@ -27,10 +27,17 @@ export function WordPopup({
     }
   }, [translation]);
 
-  const handleAddToDeck = useCallback(() => {
-    if (!translation || !onAddToDeck) return;
-    onAddToDeck(translation.word, translation.translation, translation.sourceLanguage, translation.dictionary);
-  }, [translation, onAddToDeck]);
+  const [isAdding, setIsAdding] = useState(false);
+
+  const handleAddToDeck = useCallback(async () => {
+    if (!translation || !onAddToDeck || isAdding) return;
+    setIsAdding(true);
+    try {
+      await onAddToDeck(translation.word, translation.translation, translation.sourceLanguage, translation.dictionary);
+    } finally {
+      setIsAdding(false);
+    }
+  }, [translation, onAddToDeck, isAdding]);
 
   if (!position) return null;
 
@@ -110,6 +117,14 @@ export function WordPopup({
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                     </svg>
                     In deck
+                  </span>
+                ) : isAdding ? (
+                  <span className="inline-flex items-center gap-1 text-xs text-blue-600">
+                    <svg className="animate-spin w-3.5 h-3.5" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                    </svg>
+                    Adding...
                   </span>
                 ) : (
                   <button

--- a/src/components/WordPopup.tsx
+++ b/src/components/WordPopup.tsx
@@ -119,7 +119,7 @@ export function WordPopup({
                     In deck
                   </span>
                 ) : isAdding ? (
-                  <span className="inline-flex items-center gap-1 text-xs text-blue-600">
+                  <span data-testid="adding-spinner" className="inline-flex items-center gap-1 text-xs text-blue-600">
                     <svg className="animate-spin w-3.5 h-3.5" viewBox="0 0 24 24">
                       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                       <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />


### PR DESCRIPTION
## Summary
- **addCard is now async** — awaits `enrichSingleCardExample` before adding the card to state, fixing a race condition where ReviewPanel snapshots stale cards without example sentences
- **WordPopup shows "Adding..." spinner** during the ~1-2s enrichment wait, then transitions to "In deck" checkmark
- **Server-side LRU cache** (10K entries) on `/api/generate-examples` — repeat words skip GPT entirely (no cost tracked), mixed cached/uncached batches only call GPT for uncached words

## Test plan
- [x] 372 frontend tests pass (includes 3 new async addCard tests + 1 spinner test)
- [x] 288 server tests pass (includes 3 new cache hit/miss/caching tests)
- [x] TypeScript check passes
- [x] Lint clean (0 errors)
- [x] Production build succeeds
- [ ] E2E tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)