### PR TITLE
feat(dict): reverse inflection index for grammar table lookup

### DIFF
--- a/server/dictionary.js
+++ b/server/dictionary.js
@@ -106,7 +106,8 @@ function addInflections(reverseMap, normalizedBare, row, columns) {
   for (const col of columns) {
     const raw = row[col];
     if (!raw) continue;
-    // Some cells contain comma-separated alternates (e.g. "краси'вый, краси'вого")
+    // OpenRussian inflection columns use comma-separated alternates only
+    // (e.g. "краси'вый, краси'вого"), unlike translations which also use semicolons.
     const forms = raw.split(',');
     for (const form of forms) {
       const stripped = form.trim().replace(/'/g, '');
@@ -115,6 +116,8 @@ function addInflections(reverseMap, normalizedBare, row, columns) {
       // Don't overwrite: first entry wins (bare form itself is already in main index)
       if (normalized !== normalizedBare && !reverseMap.has(normalized)) {
         reverseMap.set(normalized, normalizedBare);
+      } else if (normalized !== normalizedBare && reverseMap.get(normalized) !== normalizedBare) {
+        console.debug(`[Dictionary] inflection collision: "${normalized}" → "${normalizedBare}" (already → "${reverseMap.get(normalized)}")`);
       }
     }
   }

--- a/server/dictionary.test.js
+++ b/server/dictionary.test.js
@@ -144,6 +144,67 @@ describe('lookupWord — others', () => {
   });
 });
 
+// ── lookupWord — inflection index (no lemma needed) ─────────────────
+
+describe('lookupWord — inflection index', () => {
+  it('finds noun "книга" via accusative form "книгу"', () => {
+    const entry = lookupWord('книгу');
+    expect(entry).not.toBeNull();
+    expect(entry.pos).toBe('noun');
+    expect(entry.stressedForm).toBe('кни\u0301га');
+    expect(entry.declension.sg.acc).toBe('кни\u0301гу');
+  });
+
+  it('finds verb "говорить" via 3rd person sg "говорит"', () => {
+    const entry = lookupWord('говорит');
+    expect(entry).not.toBeNull();
+    expect(entry.pos).toBe('verb');
+    expect(entry.stressedForm).toBe('говори\u0301ть');
+    expect(entry.conjugation.present.sg3).toBe('говори\u0301т');
+  });
+
+  it('finds adjective "красивый" via feminine nom "красивая"', () => {
+    const entry = lookupWord('красивая');
+    expect(entry).not.toBeNull();
+    expect(entry.pos).toBe('adjective');
+    expect(entry.translations).toContain('beautiful');
+    expect(entry.adjectiveForms.long.f).toBe('краси\u0301вая');
+  });
+
+  it('finds "человек" via irregular plural gen "людей"', () => {
+    const entry = lookupWord('людей');
+    expect(entry).not.toBeNull();
+    expect(entry.pos).toBe('noun');
+    expect(entry.stressedForm).toBe('челове\u0301к');
+    expect(entry.declension.pl.gen).toBe('люде\u0301й');
+  });
+
+  it('finds noun via genitive plural "книг"', () => {
+    const entry = lookupWord('книг');
+    expect(entry).not.toBeNull();
+    expect(entry.pos).toBe('noun');
+    expect(entry.stressedForm).toBe('кни\u0301га');
+  });
+
+  it('finds verb via past feminine "сказала"', () => {
+    const entry = lookupWord('сказала');
+    expect(entry).not.toBeNull();
+    expect(entry.pos).toBe('verb');
+    expect(entry.aspect).toBe('perfective');
+  });
+
+  it('finds adjective via comma-separated alternate form "красивого"', () => {
+    // "красивого" appears in decl_m_gen and also as alternate in decl_m_acc
+    const entry = lookupWord('красивого');
+    expect(entry).not.toBeNull();
+    expect(entry.pos).toBe('adjective');
+  });
+
+  it('still returns null for truly unknown words', () => {
+    expect(lookupWord('абракадабра')).toBeNull();
+  });
+});
+
 // ── lookupWord — lemma fallback ───────────────────────────────────────
 
 describe('lookupWord — lemma fallback', () => {


### PR DESCRIPTION
## Summary
- **Reverse inflection index**: Builds a `Map<inflected_form, bare_form>` at server startup from OpenRussian TSV inflection columns (nouns: 12 case forms, verbs: 12 conjugation forms, adjectives: 30 declension/short/comparative forms). `lookupWord()` now resolves inflected words like "книгу" → "книга" without needing a GPT-provided lemma.
- **Zero-cost lookup**: ~15-25 MB RAM, <1ms hash lookup vs 5-10s GPT call. Handles comma-separated alternate forms and strips apostrophe stress marks before indexing.
- **ReviewPanel race condition fix**: Combined separate `setQueue()` + `popNext()` calls into a single atomic state update to prevent React batching from reading stale queue state when re-queuing learning cards.

## Test plan
- [x] 8 new unit tests for inflection lookup (noun acc, verb 3rd sg, adj fem nom, irregular plural, gen pl, past fem, comma alternates, unknown word)
- [x] All 27 dictionary tests pass
- [x] Full test suite passes (391 frontend + 296 server = 687 tests)
- [ ] Manual: click inflected word in transcript → add to deck → review → card back shows grammar table

🤖 Generated with [Claude Code](https://claude.com/claude-code)