### PR TITLE
feat(library): content library + demo load-more

### DIFF
--- a/CLAUDE_DOCS/content-library.md
+++ b/CLAUDE_DOCS/content-library.md
@@ -1,0 +1,39 @@
+# Feature: Content Library
+> Browse and instantly open previously analyzed content from all users.
+
+## Overview
+The Content Library is an in-memory index of all sessions across all users, deduplicated by normalized URL (most recent session wins). Users can browse available content on the landing page and click to open — cloning the source session gives instant access to existing chunks without re-analyzing.
+
+No subscription required to browse. Auth required (global middleware).
+
+## How It Works
+
+### Library Index (`server/storage/library-index.js`)
+- `Map<normalizedUrl, LibraryEntry>` — deduplicated by URL
+- Rebuilt from GCS on startup via `rebuildUrlCache()`
+- Updated incrementally on `setAnalysisSession()` and `deleteSessionAndVideos()`
+
+### Session Cloning (`POST /api/library/open`)
+When a user opens a library item, `cloneSession()` creates a new session owned by the current user. Media files are NOT copied — fresh signed URLs are generated pointing to the original session's GCS objects (signed URLs are bucket-scoped, not user-scoped).
+
+### Frontend (`src/components/Library.tsx`)
+Card grid rendered below demo buttons on the landing page. Shows title, content type badge, chunk count, duration, and relative date.
+
+## API Endpoints
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/api/library` | GET | Yes | Returns `{ items: LibraryItem[] }` sorted by createdAt desc |
+| `/api/library/open` | POST | Yes | Body: `{ sourceSessionId }`. Clones session for current user |
+
+## Resources
+- [Demo Load More](demo-load-more.md) — related feature for extending demo content
+
+## Assets
+- `server/storage/library-index.js` — In-memory library index
+- `server/storage/session-repository.js` — `cloneSession()`, library integration
+- `server/session-store.js` — Barrel exports
+- `server/index.js` — Library endpoints
+- `src/components/Library.tsx` — Frontend component
+- `src/services/api.ts` — `fetchLibrary()`, `openLibraryItem()`
+- `src/App.tsx` — Library state, fetch, handler

--- a/CLAUDE_DOCS/demo-load-more.md
+++ b/CLAUDE_DOCS/demo-load-more.md
@@ -1,0 +1,31 @@
+# Feature: Demo Load More
+> Demo sessions now support "Load More Parts" for video, and show all text sections upfront.
+
+## Overview
+Previously, demo sessions were in-memory only with `hasMoreChunks: false`. Now:
+
+- **Video demo**: Pre-bakes first N chunks. Stores full `transcript` and `nextBatchStartTime` so the existing load-more pipeline can download more audio from ok.ru in real-time.
+- **Text demo**: Stores `rawText`. On demo load, ALL text chunks are created via `createTextChunks()` — pre-baked chunks are `status: 'ready'` (with TTS audio), remaining are `status: 'pending'` (TTS generated on-demand when clicked).
+
+## Key Changes
+
+### generate-demo.js
+- Video output now includes: `transcript`, `nextBatchStartTime`, `hasMoreChunks`
+- Text output now includes: `rawText` (full book text for on-demand chunking)
+
+### Demo Endpoint (`POST /api/demo`)
+- Sessions persisted to GCS via `setAnalysisSession()` (required for load-more to find the session)
+- Video: sets `session.transcript` and `session.nextBatchStartTime` from demo JSON
+- Text: calls `createTextChunks(rawText)` to create all chunks; marks pre-baked as ready, rest as pending
+
+### No Changes to Load-More Endpoint
+The existing `POST /api/load-more-chunks` already handles any session with `hasMoreChunks: true` and `nextBatchStartTime`. Demo sessions just need the right fields set.
+
+## Resources
+- [Content Library](content-library.md) — library uses the same persisted sessions
+
+## Assets
+- `server/scripts/generate-demo.js` — Demo generator with new fields
+- `server/index.js` — Modified demo endpoint
+- `server/demo/demo-video.json` — Pre-baked video demo (re-generate to get new fields)
+- `server/demo/demo-text.json` — Pre-baked text demo (re-generate to get rawText)

--- a/server/index.js
+++ b/server/index.js
@@ -778,7 +778,8 @@ app.post('/api/demo', demoRateLimit, async (req, res) => {
  * No subscription required. Auth required (global middleware).
  */
 app.get('/api/library', (req, res) => {
-  const entries = getLibraryEntries();
+  // Strip url from entries to avoid leaking other users' content choices
+  const entries = getLibraryEntries().map(({ url, ...rest }) => rest);
   res.json({ items: entries });
 });
 
@@ -788,7 +789,7 @@ app.get('/api/library', (req, res) => {
  * to existing chunks without re-analyzing.
  * Body: { sourceSessionId }
  */
-app.post('/api/library/open', async (req, res) => {
+app.post('/api/library/open', demoRateLimit, async (req, res) => {
   const { sourceSessionId } = req.body;
   if (!sourceSessionId) {
     return res.status(400).json({ error: 'sourceSessionId is required' });

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ import {
   getAnalysisSession, setAnalysisSession,
   deleteSessionAndVideos,
   cleanupOldSessions, rebuildUrlCache,
+  cloneSession, getLibraryEntries,
   init as initSessionStore,
 } from './session-store.js';
 import { progressClients, sendProgress, createProgressCallback, friendlyErrorMessage } from './progress.js';
@@ -692,6 +693,42 @@ app.post('/api/demo', demoRateLimit, async (req, res) => {
     }
   }
 
+  // For text mode with rawText: create ALL text chunks, mark pre-baked ones as ready
+  let allChunks = chunks;
+  const chunkTranscriptsMap = new Map(demoData.chunkTranscripts);
+  let chunkTextsMap = demoData.chunkTexts ? new Map(demoData.chunkTexts) : undefined;
+
+  if (type === 'text' && demoData.rawText) {
+    const allTextChunks = createTextChunks(demoData.rawText);
+    const preBakedIds = new Set(chunks.map(c => c.id));
+
+    allChunks = allTextChunks.map((tc, i) => {
+      const preBaked = chunks.find(c => c.index === i);
+      if (preBaked && preBakedIds.has(preBaked.id)) {
+        return preBaked; // Already has status='ready' and audioUrl
+      }
+      return {
+        id: tc.id,
+        index: tc.index,
+        startTime: 0,
+        endTime: 0,
+        duration: 0,
+        previewText: tc.previewText,
+        wordCount: tc.wordCount,
+        status: 'pending',
+        audioUrl: null,
+      };
+    });
+
+    // Store all chunk texts for on-demand TTS generation
+    if (!chunkTextsMap) chunkTextsMap = new Map();
+    for (const tc of allTextChunks) {
+      if (!chunkTextsMap.has(tc.id)) {
+        chunkTextsMap.set(tc.id, tc.text);
+      }
+    }
+  }
+
   // Build session with real ownership
   const session = {
     status: 'ready',
@@ -699,22 +736,30 @@ app.post('/api/demo', demoRateLimit, async (req, res) => {
     uid: req.uid,
     title: demoData.title,
     contentType: demoData.contentType,
-    chunks,
+    chunks: allChunks,
     totalDuration: demoData.totalDuration,
     hasMoreChunks: demoData.hasMoreChunks || false,
-    chunkTranscripts: new Map(demoData.chunkTranscripts),
+    chunkTranscripts: chunkTranscriptsMap,
     isDemo: true,
   };
 
-  // For text mode, also restore chunkTexts if present
-  if (demoData.chunkTexts) {
-    session.chunkTexts = new Map(demoData.chunkTexts);
+  // For video: include transcript and nextBatchStartTime for load-more support
+  if (demoData.transcript) {
+    session.transcript = demoData.transcript;
+  }
+  if (demoData.nextBatchStartTime != null) {
+    session.nextBatchStartTime = demoData.nextBatchStartTime;
   }
 
-  // Demo sessions are in-memory only — no GCS write needed since data comes from pre-baked JSON
-  analysisSessions.set(sessionId, session);
+  // For text mode: store chunkTexts for on-demand TTS
+  if (chunkTextsMap) {
+    session.chunkTexts = chunkTextsMap;
+  }
 
-  console.log(`[Demo] Created ${type} session ${sessionId} for user ${req.uid}`);
+  // Persist to GCS so load-more and library endpoints can find the session
+  await setAnalysisSession(sessionId, session);
+
+  console.log(`[Demo] Created ${type} session ${sessionId} for user ${req.uid} (hasMore: ${session.hasMoreChunks})`);
 
   res.json({
     sessionId,
@@ -722,8 +767,54 @@ app.post('/api/demo', demoRateLimit, async (req, res) => {
     title: demoData.title,
     contentType: demoData.contentType,
     totalDuration: demoData.totalDuration,
-    chunks,
-    hasMoreChunks: demoData.hasMoreChunks || false,
+    chunks: allChunks,
+    hasMoreChunks: session.hasMoreChunks,
+  });
+});
+
+/**
+ * GET /api/library
+ * Browse all cached sessions across all users, ordered most recent first.
+ * No subscription required. Auth required (global middleware).
+ */
+app.get('/api/library', (req, res) => {
+  const entries = getLibraryEntries();
+  res.json({ items: entries });
+});
+
+/**
+ * POST /api/library/open
+ * Clone a library session for the current user, giving instant access
+ * to existing chunks without re-analyzing.
+ * Body: { sourceSessionId }
+ */
+app.post('/api/library/open', async (req, res) => {
+  const { sourceSessionId } = req.body;
+  if (!sourceSessionId) {
+    return res.status(400).json({ error: 'sourceSessionId is required' });
+  }
+
+  const source = await getAnalysisSession(sourceSessionId);
+  if (!source) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const newSessionId = crypto.randomUUID();
+  const cloned = await cloneSession(source, sourceSessionId, req.uid);
+
+  await setAnalysisSession(newSessionId, cloned);
+  cacheSessionUrl(cloned.url, newSessionId, req.uid);
+
+  console.log(`[Library] Cloned session ${sourceSessionId} → ${newSessionId} for user ${req.uid}`);
+
+  res.json({
+    sessionId: newSessionId,
+    status: 'cached',
+    title: cloned.title,
+    contentType: cloned.contentType,
+    totalDuration: cloned.totalDuration,
+    chunks: cloned.chunks,
+    hasMoreChunks: cloned.hasMoreChunks,
   });
 });
 

--- a/server/scripts/generate-demo.js
+++ b/server/scripts/generate-demo.js
@@ -9,6 +9,14 @@
  *
  * Usage:
  *   cd server && node scripts/generate-demo.js [--video] [--text] [--upload-gcs]
+ *                                               [--max-chunks N] [--resume]
+ *
+ * Flags:
+ *   --video         Generate video demo (default if neither --video nor --text)
+ *   --text          Generate text demo (default if neither --video nor --text)
+ *   --upload-gcs    Upload media files to GCS after generation
+ *   --max-chunks N  Limit to first N chunks (default: no limit, process everything)
+ *   --resume        Resume from partial progress (skip already-processed chunks)
  *
  * Requires:
  *   - OPENAI_API_KEY in ../.env
@@ -47,14 +55,22 @@ dotenv.config({ path: path.join(serverDir, '..', '.env') });
 const DEMO_VIDEO_URL = 'https://ok.ru/video/400776431053';
 const DEMO_TEXT_URL = 'http://az.lib.ru/t/tolstoj_lew_nikolaewich/text_0080.shtml';
 
-// Limit demo content to first ~10 minutes / 3 chunks
-const MAX_DEMO_CHUNKS = 3;
-const MAX_DEMO_AUDIO_SECONDS = 10 * 60;
+// Whisper API has a 25MB file limit; 10-min MP3 segments stay well under that
+const SEGMENT_DURATION = 10 * 60;
 
 const args = process.argv.slice(2);
 const doVideo = args.includes('--video') || (!args.includes('--text'));
 const doText = args.includes('--text') || (!args.includes('--video'));
 const uploadGcs = args.includes('--upload-gcs');
+const doResume = args.includes('--resume');
+
+// Parse --max-chunks N
+const maxChunksIdx = args.indexOf('--max-chunks');
+const maxChunks = maxChunksIdx >= 0 ? parseInt(args[maxChunksIdx + 1], 10) : Infinity;
+if (maxChunksIdx >= 0 && (!Number.isFinite(maxChunks) || maxChunks < 1)) {
+  console.error('Error: --max-chunks requires a positive integer');
+  process.exit(1);
+}
 
 // Ensure directories exist
 for (const dir of [demoDir, mediaDir, tempDir]) {
@@ -67,54 +83,133 @@ const silentProgress = () => {};
 async function generateVideoDemo() {
   console.log('\n=== Generating Video Demo ===');
   console.log(`URL: ${DEMO_VIDEO_URL}`);
+  if (maxChunks < Infinity) console.log(`Max chunks: ${maxChunks}`);
 
-  // Step 1: Get video info
-  console.log('[1/6] Fetching video info...');
-  const info = await getOkRuVideoInfo(DEMO_VIDEO_URL);
-  console.log(`  Title: ${info.title} (${Math.round(info.duration / 60)} min)`);
+  const partialPath = path.join(demoDir, 'demo-video.partial.json');
+  let partial = null;
 
-  // Step 2: Download audio (first ~10 min)
-  const downloadEnd = Math.min(MAX_DEMO_AUDIO_SECONDS, info.duration);
-  const audioPath = path.join(tempDir, 'demo_video_audio.mp3');
-  console.log(`[2/6] Downloading audio (0 - ${Math.round(downloadEnd / 60)} min)...`);
-  await downloadAudioChunk(DEMO_VIDEO_URL, audioPath, 0, downloadEnd, {
-    onProgress: silentProgress,
-    fetchInfo: true,
-  });
+  if (doResume && fs.existsSync(partialPath)) {
+    partial = JSON.parse(fs.readFileSync(partialPath, 'utf-8'));
+    console.log(`  Resuming: ${partial.completedChunks.length}/${partial.demoChunks.length} chunks done`);
+  }
 
-  // Step 3: Transcribe
-  console.log('[3/6] Transcribing with Whisper...');
-  const rawTranscript = await transcribeAudioChunk(audioPath, { onProgress: silentProgress });
+  let info, transcript, demoChunks;
+  // Persists across audio segments + video chunks for yt-dlp performance
+  let cachedInfoPath = null;
 
-  // Step 4: Punctuate
-  console.log('[4/6] Adding punctuation with GPT-4o...');
-  const transcript = await addPunctuation(rawTranscript, { onProgress: silentProgress });
+  if (partial?.transcript) {
+    // Resume: reuse saved transcript and chunks
+    info = { title: partial.title, duration: partial.totalDuration };
+    transcript = partial.transcript;
+    demoChunks = partial.demoChunks;
+  } else {
+    // Step 1: Get video info
+    console.log('[1/5] Fetching video info...');
+    info = await getOkRuVideoInfo(DEMO_VIDEO_URL);
+    const totalMin = Math.round(info.duration / 60);
+    const numSegments = Math.ceil(info.duration / SEGMENT_DURATION);
+    console.log(`  Title: ${info.title} (${totalMin} min, ${numSegments} segments)`);
 
-  // Clean up audio
-  fs.unlinkSync(audioPath);
+    // Step 2: Download + transcribe audio in 10-min segments
+    console.log(`[2/5] Downloading + transcribing audio (${numSegments} × ${SEGMENT_DURATION / 60} min)...`);
+    const allWords = [];
+    const allSegments = [];
 
-  // Step 5: Create chunks, take first N
-  console.log('[5/6] Creating chunks...');
-  const allChunks = createChunks(transcript);
-  const demoChunks = allChunks.slice(0, MAX_DEMO_CHUNKS);
-  console.log(`  ${allChunks.length} total chunks, keeping ${demoChunks.length}`);
+    for (let start = 0; start < info.duration; start += SEGMENT_DURATION) {
+      const end = Math.min(start + SEGMENT_DURATION, info.duration);
+      const segPath = path.join(tempDir, `demo_video_seg_${start}.mp3`);
+      const segNum = Math.floor(start / SEGMENT_DURATION) + 1;
 
-  // Step 6: Download video for each chunk + lemmatize
-  console.log('[6/6] Downloading video chunks + lemmatizing...');
-  const gcsMediaKeys = {};
-  const localMediaFiles = {};
-  const chunkTranscripts = [];
+      console.log(`  Segment ${segNum}/${numSegments}: ${Math.round(start / 60)}-${Math.round(end / 60)} min`);
+
+      const isFirst = start === 0;
+      await downloadAudioChunk(DEMO_VIDEO_URL, segPath, start, end, {
+        onProgress: silentProgress,
+        fetchInfo: isFirst,
+        cachedInfoPath: isFirst ? null : cachedInfoPath,
+      });
+
+      // After first segment, grab the info JSON for subsequent downloads
+      if (isFirst) {
+        const infoJsonPath = segPath + '.info.json';
+        if (fs.existsSync(infoJsonPath)) {
+          cachedInfoPath = infoJsonPath;
+          console.log('  Cached extraction info for subsequent downloads');
+        }
+      }
+
+      console.log('  Transcribing segment...');
+      const seg = await transcribeAudioChunk(segPath, { onProgress: silentProgress });
+
+      // Offset timestamps to global timeline
+      for (const w of seg.words) {
+        allWords.push({ ...w, start: w.start + start, end: w.end + start });
+      }
+      for (const s of seg.segments) {
+        allSegments.push({ ...s, start: s.start + start, end: s.end + start });
+      }
+
+      fs.unlinkSync(segPath);
+      console.log(`  Segment ${segNum} done (${seg.words.length} words)`);
+    }
+
+    console.log(`  Total: ${allWords.length} words, ${allSegments.length} segments`);
+
+    const rawTranscript = {
+      words: allWords,
+      segments: allSegments,
+      language: 'ru',
+      duration: info.duration,
+    };
+
+    // Step 3: Punctuate
+    console.log('[3/5] Adding punctuation with GPT-4o...');
+    transcript = await addPunctuation(rawTranscript, { onProgress: silentProgress });
+
+    // Step 4: Create chunks
+    console.log('[4/5] Creating chunks...');
+    const allChunks = createChunks(transcript);
+    demoChunks = maxChunks < Infinity ? allChunks.slice(0, maxChunks) : allChunks;
+    console.log(`  ${allChunks.length} total chunks, keeping ${demoChunks.length}`);
+
+    // Save partial progress (transcript + chunks, before expensive per-chunk work)
+    const partialData = {
+      title: info.title,
+      totalDuration: info.duration,
+      transcript,
+      demoChunks,
+      completedChunks: [],
+      chunkTranscripts: [],
+      gcsMediaKeys: {},
+      localMediaFiles: {},
+    };
+    fs.writeFileSync(partialPath, JSON.stringify(partialData));
+    console.log('  Saved partial progress (transcript + chunks)');
+  }
+
+  // Step 5: Download video for each chunk + lemmatize
+  console.log(`[5/5] Downloading video chunks + lemmatizing (${demoChunks.length} chunks)...`);
+  const gcsMediaKeys = partial?.gcsMediaKeys || {};
+  const localMediaFiles = partial?.localMediaFiles || {};
+  const chunkTranscripts = partial?.chunkTranscripts || [];
+  const completedChunkIds = new Set(partial?.completedChunks || []);
 
   for (const chunk of demoChunks) {
+    if (completedChunkIds.has(chunk.id)) {
+      console.log(`  Chunk ${chunk.id}: already done (resuming)`);
+      continue;
+    }
+
     const videoFilename = `demo-video-${chunk.id}.mp4`;
     const videoPath = path.join(mediaDir, videoFilename);
 
-    console.log(`  Chunk ${chunk.id}: ${Math.round(chunk.startTime)}s - ${Math.round(chunk.endTime)}s`);
+    console.log(`  Chunk ${chunk.id} [${chunk.index + 1}/${demoChunks.length}]: ${Math.round(chunk.startTime)}s - ${Math.round(chunk.endTime)}s`);
 
-    // Download video segment
+    // Download video segment (reuse cached info from audio download if available)
     await downloadVideoChunk(DEMO_VIDEO_URL, videoPath, chunk.startTime, chunk.endTime, {
       onProgress: silentProgress,
       partNum: chunk.index + 1,
+      cachedInfoPath,
     });
 
     // Get chunk transcript and lemmatize
@@ -124,15 +219,40 @@ async function generateVideoDemo() {
     chunkTranscripts.push([chunk.id, chunkTranscript]);
     gcsMediaKeys[chunk.id] = `demo/${videoFilename}`;
     localMediaFiles[chunk.id] = videoFilename;
+    completedChunkIds.add(chunk.id);
+
+    // Save partial progress after each chunk
+    const partialData = {
+      title: info.title,
+      totalDuration: info.duration,
+      transcript,
+      demoChunks,
+      completedChunks: [...completedChunkIds],
+      chunkTranscripts,
+      gcsMediaKeys,
+      localMediaFiles,
+    };
+    fs.writeFileSync(partialPath, JSON.stringify(partialData));
+    console.log(`  Progress saved (${completedChunkIds.size}/${demoChunks.length} chunks)`);
+  }
+
+  // Clean up cached extraction info
+  if (cachedInfoPath && fs.existsSync(cachedInfoPath)) {
+    fs.unlinkSync(cachedInfoPath);
   }
 
   const lastChunk = demoChunks[demoChunks.length - 1];
+  const lastChunkEndTime = lastChunk ? lastChunk.endTime : 0;
+  const moreAvailable = lastChunkEndTime < info.duration;
+
   const demoData = {
     title: info.title,
     contentType: 'video',
-    totalDuration: lastChunk.endTime,
+    totalDuration: info.duration,
     originalUrl: DEMO_VIDEO_URL,
-    hasMoreChunks: false,
+    hasMoreChunks: moreAvailable,
+    nextBatchStartTime: moreAvailable ? lastChunkEndTime : null,
+    transcript,
     chunks: demoChunks.map(c => ({
       id: c.id,
       index: c.index,
@@ -153,37 +273,78 @@ async function generateVideoDemo() {
   console.log(`\nSaved: ${jsonPath}`);
   console.log(`Media files in: ${mediaDir}`);
 
+  // Clean up partial file
+  if (fs.existsSync(partialPath)) fs.unlinkSync(partialPath);
+
   return demoData;
 }
 
 async function generateTextDemo() {
   console.log('\n=== Generating Text Demo ===');
   console.log(`URL: ${DEMO_TEXT_URL}`);
+  if (maxChunks < Infinity) console.log(`Max chunks: ${maxChunks}`);
 
-  // Step 1: Fetch text
-  console.log('[1/5] Fetching text from lib.ru...');
-  const { title, author, text } = await fetchLibRuText(DEMO_TEXT_URL);
-  const displayTitle = author ? `${author} — ${title}` : title;
-  console.log(`  Title: ${displayTitle} (${text.length} chars)`);
+  const partialPath = path.join(demoDir, 'demo-text.partial.json');
+  let partial = null;
 
-  // Step 2: Create text chunks, take first N
-  console.log('[2/5] Creating text chunks...');
-  const allTextChunks = createTextChunks(text);
-  const demoTextChunks = allTextChunks.slice(0, MAX_DEMO_CHUNKS);
-  console.log(`  ${allTextChunks.length} total chunks, keeping ${demoTextChunks.length}`);
+  if (doResume && fs.existsSync(partialPath)) {
+    partial = JSON.parse(fs.readFileSync(partialPath, 'utf-8'));
+    console.log(`  Resuming: ${partial.completedChunks.length}/${partial.demoTextChunks.length} chunks done`);
+  }
 
-  // Step 3-5: Generate TTS + timestamps for each chunk
-  console.log('[3/5] Generating TTS audio + timestamps...');
-  const gcsMediaKeys = {};
-  const localMediaFiles = {};
-  const chunkTranscripts = [];
-  const chunkTexts = [];
+  let displayTitle, demoTextChunks, rawText;
+
+  if (partial?.demoTextChunks) {
+    // Resume: reuse saved chunks
+    displayTitle = partial.title;
+    demoTextChunks = partial.demoTextChunks;
+    rawText = partial.rawText;
+  } else {
+    // Step 1: Fetch text
+    console.log('[1/3] Fetching text from lib.ru...');
+    const { title, author, text } = await fetchLibRuText(DEMO_TEXT_URL);
+    displayTitle = author ? `${author} — ${title}` : title;
+    rawText = text;
+    console.log(`  Title: ${displayTitle} (${text.length} chars)`);
+
+    // Step 2: Create text chunks
+    console.log('[2/3] Creating text chunks...');
+    const allTextChunks = createTextChunks(text);
+    demoTextChunks = maxChunks < Infinity ? allTextChunks.slice(0, maxChunks) : allTextChunks;
+    console.log(`  ${allTextChunks.length} total chunks, keeping ${demoTextChunks.length}`);
+
+    // Save partial progress
+    const partialData = {
+      title: displayTitle,
+      rawText,
+      demoTextChunks,
+      completedChunks: [],
+      chunkTranscripts: [],
+      chunkTexts: [],
+      gcsMediaKeys: {},
+      localMediaFiles: {},
+    };
+    fs.writeFileSync(partialPath, JSON.stringify(partialData));
+  }
+
+  // Step 3: Generate TTS + timestamps for each chunk
+  console.log(`[3/3] Generating TTS + timestamps + lemmatization (${demoTextChunks.length} chunks)...`);
+  const gcsMediaKeys = partial?.gcsMediaKeys || {};
+  const localMediaFiles = partial?.localMediaFiles || {};
+  const chunkTranscripts = partial?.chunkTranscripts || [];
+  const chunkTexts = partial?.chunkTexts || [];
+  const completedChunkIds = new Set(partial?.completedChunks || []);
 
   for (const chunk of demoTextChunks) {
+    if (completedChunkIds.has(chunk.id)) {
+      console.log(`  Chunk ${chunk.id}: already done (resuming)`);
+      continue;
+    }
+
     const audioFilename = `demo-text-${chunk.id}.mp3`;
     const audioPath = path.join(mediaDir, audioFilename);
 
-    console.log(`  Chunk ${chunk.id}: ${chunk.text.length} chars`);
+    console.log(`  Chunk ${chunk.id} [${chunk.index + 1}/${demoTextChunks.length}]: ${chunk.text.length} chars`);
 
     // Generate TTS
     await generateTtsAudio(chunk.text, audioPath, { onProgress: silentProgress });
@@ -198,6 +359,20 @@ async function generateTextDemo() {
     chunkTexts.push([chunk.id, chunk.text]);
     gcsMediaKeys[chunk.id] = `demo/${audioFilename}`;
     localMediaFiles[chunk.id] = audioFilename;
+    completedChunkIds.add(chunk.id);
+
+    // Save partial progress after each chunk
+    const partialData = {
+      title: displayTitle,
+      demoTextChunks,
+      completedChunks: [...completedChunkIds],
+      chunkTranscripts,
+      chunkTexts,
+      gcsMediaKeys,
+      localMediaFiles,
+    };
+    fs.writeFileSync(partialPath, JSON.stringify(partialData));
+    console.log(`  Progress saved (${completedChunkIds.size}/${demoTextChunks.length} chunks)`);
   }
 
   const demoData = {
@@ -206,6 +381,7 @@ async function generateTextDemo() {
     totalDuration: 0,
     originalUrl: DEMO_TEXT_URL,
     hasMoreChunks: false,
+    rawText,
     chunks: demoTextChunks.map(c => ({
       id: c.id,
       index: c.index,
@@ -226,6 +402,9 @@ async function generateTextDemo() {
   fs.writeFileSync(jsonPath, JSON.stringify(demoData, null, 2));
   console.log(`\nSaved: ${jsonPath}`);
   console.log(`Media files in: ${mediaDir}`);
+
+  // Clean up partial file
+  if (fs.existsSync(partialPath)) fs.unlinkSync(partialPath);
 
   return demoData;
 }
@@ -263,6 +442,8 @@ async function uploadToGcs(demoData) {
 async function main() {
   console.log('Demo Content Generator');
   console.log('======================');
+  if (maxChunks < Infinity) console.log(`Chunk limit: ${maxChunks}`);
+  if (doResume) console.log('Resume mode: ON');
 
   if (!process.env.OPENAI_API_KEY) {
     console.error('Error: OPENAI_API_KEY not set in .env');

--- a/server/session-store.js
+++ b/server/session-store.js
@@ -26,7 +26,11 @@ export {
   setAnalysisSession,
   cleanupOldSessions,
   rebuildUrlCache,
+  cloneSession,
 } from './storage/session-repository.js';
+
+// Library index
+export { addToLibrary, removeFromLibrary, getLibraryEntries } from './storage/library-index.js';
 
 // Wrap getCachedSession to inject getAnalysisSession (breaks circular dependency
 // between url-cache.js and session-repository.js)

--- a/server/storage/library-index.js
+++ b/server/storage/library-index.js
@@ -11,6 +11,9 @@ const libraryByUrl = new Map();
 // Reverse lookup: sessionId → normalizedUrl (for efficient removal)
 const sessionToUrl = new Map();
 
+// Cached sorted array — invalidated on add/remove
+let sortedCache = null;
+
 /**
  * Add or update a library entry for a session.
  * Only keeps the most recent session per URL.
@@ -44,6 +47,7 @@ export function addToLibrary(sessionId, session, createdAt) {
 
   libraryByUrl.set(normalized, entry);
   sessionToUrl.set(sessionId, normalized);
+  sortedCache = null; // Invalidate
 }
 
 /**
@@ -59,13 +63,18 @@ export function removeFromLibrary(sessionId) {
   const entry = libraryByUrl.get(normalized);
   if (entry && entry.sessionId === sessionId) {
     libraryByUrl.delete(normalized);
+    sortedCache = null; // Invalidate
   }
 }
 
 /**
  * Get all library entries, sorted by createdAt descending (most recent first).
+ * Caches the sorted result until the next add/remove.
  */
 export function getLibraryEntries() {
-  return Array.from(libraryByUrl.values())
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  if (!sortedCache) {
+    sortedCache = Array.from(libraryByUrl.values())
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }
+  return sortedCache;
 }

--- a/server/storage/library-index.js
+++ b/server/storage/library-index.js
@@ -1,0 +1,71 @@
+/**
+ * In-memory library index — a browseable catalog of all sessions across all users.
+ * Deduplicated by normalized URL (most recent session wins).
+ * Rebuilt from GCS on startup; updated incrementally on session save/delete.
+ */
+import { normalizeUrl } from './url-utils.js';
+
+// Map<normalizedUrl, LibraryEntry>
+const libraryByUrl = new Map();
+
+// Reverse lookup: sessionId → normalizedUrl (for efficient removal)
+const sessionToUrl = new Map();
+
+/**
+ * Add or update a library entry for a session.
+ * Only keeps the most recent session per URL.
+ */
+export function addToLibrary(sessionId, session, createdAt) {
+  if (!session.url || !session.title || session.status !== 'ready') return;
+
+  const normalized = normalizeUrl(session.url);
+  const entry = {
+    sessionId,
+    title: session.title,
+    contentType: session.contentType || 'video',
+    url: session.url,
+    chunkCount: session.chunks?.length || 0,
+    totalDuration: session.totalDuration || 0,
+    hasMoreChunks: session.hasMoreChunks || false,
+    createdAt: createdAt instanceof Date ? createdAt.toISOString() : createdAt,
+  };
+
+  const existing = libraryByUrl.get(normalized);
+  if (existing && new Date(existing.createdAt) > new Date(entry.createdAt)) {
+    // Existing entry is newer — only update the reverse lookup
+    sessionToUrl.set(sessionId, normalized);
+    return;
+  }
+
+  // Remove old session's reverse lookup if replacing
+  if (existing) {
+    sessionToUrl.delete(existing.sessionId);
+  }
+
+  libraryByUrl.set(normalized, entry);
+  sessionToUrl.set(sessionId, normalized);
+}
+
+/**
+ * Remove a session from the library.
+ * If this was the canonical entry for its URL, the URL is removed from the index.
+ */
+export function removeFromLibrary(sessionId) {
+  const normalized = sessionToUrl.get(sessionId);
+  if (!normalized) return;
+
+  sessionToUrl.delete(sessionId);
+
+  const entry = libraryByUrl.get(normalized);
+  if (entry && entry.sessionId === sessionId) {
+    libraryByUrl.delete(normalized);
+  }
+}
+
+/**
+ * Get all library entries, sorted by createdAt descending (most recent first).
+ */
+export function getLibraryEntries() {
+  return Array.from(libraryByUrl.values())
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+}

--- a/server/storage/session-repository.js
+++ b/server/storage/session-repository.js
@@ -6,6 +6,8 @@ import fs from 'fs';
 import { LRUCache } from 'lru-cache';
 import { isLocal, getBucket, deleteGcsFile } from './gcs.js';
 import { cacheSessionUrl } from './url-cache.js';
+import { addToLibrary, removeFromLibrary } from './library-index.js';
+import { getSignedMediaUrl } from './gcs.js';
 
 // In-memory session storage for local development
 export const localSessions = new Map();
@@ -66,8 +68,9 @@ export async function deleteSessionAndVideos(sessionId) {
     await deleteGcsFile(`sessions/${sessionId}.json`);
   }
 
-  // Clean up memory cache
+  // Clean up memory cache + library index
   analysisSessions.delete(sessionId);
+  removeFromLibrary(sessionId);
 
   if (isLocal()) {
     // Clean up local files
@@ -122,6 +125,9 @@ export async function getAnalysisSession(sessionId) {
 export async function setAnalysisSession(sessionId, session) {
   // Save to memory
   analysisSessions.set(sessionId, session);
+
+  // Update library index
+  addToLibrary(sessionId, session, new Date());
 
   // Save to GCS (serialize Map to array for JSON)
   const sessionToSave = {
@@ -200,11 +206,14 @@ export async function rebuildUrlCache() {
       try {
         const [contents] = await file.download();
         const session = JSON.parse(contents.toString());
+        const sessionId = file.name.replace('sessions/', '').replace('.json', '');
         if (session.status === 'ready' && session.url && session.uid) {
-          const sessionId = file.name.replace('sessions/', '').replace('.json', '');
           cacheSessionUrl(session.url, sessionId, session.uid);
           cached++;
         }
+        // Populate library index (all ready sessions, regardless of uid)
+        const [metadata] = await file.getMetadata();
+        addToLibrary(sessionId, session, metadata.timeCreated);
       } catch {
         // Skip unreadable sessions
       }
@@ -214,4 +223,46 @@ export async function rebuildUrlCache() {
   } catch (err) {
     console.error('[Startup] Failed to rebuild URL cache:', err.message);
   }
+}
+
+/**
+ * Clone a session for a new user (used by library open).
+ * Re-signs GCS media URLs pointing to the source session's files.
+ * Does NOT copy GCS media — signed URLs are bucket-scoped, not user-scoped.
+ */
+export async function cloneSession(source, sourceSessionId, newUid) {
+  const cloned = {
+    ...source,
+    uid: newUid,
+    chunkTranscripts: source.chunkTranscripts instanceof Map
+      ? new Map(source.chunkTranscripts)
+      : new Map(source.chunkTranscripts || []),
+    chunkTexts: source.chunkTexts instanceof Map
+      ? new Map(source.chunkTexts)
+      : source.chunkTexts ? new Map(source.chunkTexts) : undefined,
+    chunks: source.chunks.map(c => ({ ...c })),
+  };
+
+  // Re-sign GCS URLs for ready chunks (pointing to source session's media files)
+  if (!isLocal()) {
+    for (const chunk of cloned.chunks) {
+      if (chunk.status === 'ready') {
+        const isDemo = source.isDemo;
+        if (chunk.videoUrl) {
+          const gcsKey = isDemo
+            ? `demo/demo-video-${chunk.id}.mp4`
+            : `videos/${sourceSessionId}_${chunk.id}.mp4`;
+          chunk.videoUrl = await getSignedMediaUrl(gcsKey);
+        }
+        if (chunk.audioUrl) {
+          const gcsKey = isDemo
+            ? `demo/demo-text-${chunk.id}.mp3`
+            : `videos/${sourceSessionId}_${chunk.id}.mp3`;
+          chunk.audioUrl = await getSignedMediaUrl(gcsKey);
+        }
+      }
+    }
+  }
+
+  return cloned;
 }

--- a/server/storage/session-repository.js
+++ b/server/storage/session-repository.js
@@ -4,10 +4,9 @@
  */
 import fs from 'fs';
 import { LRUCache } from 'lru-cache';
-import { isLocal, getBucket, deleteGcsFile } from './gcs.js';
+import { isLocal, getBucket, deleteGcsFile, getSignedMediaUrl } from './gcs.js';
 import { cacheSessionUrl } from './url-cache.js';
 import { addToLibrary, removeFromLibrary } from './library-index.js';
-import { getSignedMediaUrl } from './gcs.js';
 
 // In-memory session storage for local development
 export const localSessions = new Map();
@@ -210,10 +209,10 @@ export async function rebuildUrlCache() {
         if (session.status === 'ready' && session.url && session.uid) {
           cacheSessionUrl(session.url, sessionId, session.uid);
           cached++;
+          // Populate library index (only ready sessions)
+          const [metadata] = await file.getMetadata();
+          addToLibrary(sessionId, session, metadata.timeCreated);
         }
-        // Populate library index (all ready sessions, regardless of uid)
-        const [metadata] = await file.getMetadata();
-        addToLibrary(sessionId, session, metadata.timeCreated);
       } catch {
         // Skip unreadable sessions
       }
@@ -234,6 +233,12 @@ export async function cloneSession(source, sourceSessionId, newUid) {
   const cloned = {
     ...source,
     uid: newUid,
+    // Deep-clone transcript to avoid mutation via load-more's .push()
+    transcript: source.transcript ? {
+      ...source.transcript,
+      words: [...source.transcript.words],
+      segments: [...source.transcript.segments],
+    } : undefined,
     chunkTranscripts: source.chunkTranscripts instanceof Map
       ? new Map(source.chunkTranscripts)
       : new Map(source.chunkTranscripts || []),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ProgressBar } from './components/ProgressBar';
 import { DeckBadge } from './components/DeckBadge';
 import { LandingPage } from './components/LandingPage';
 import { PaywallScreen } from './components/PaywallScreen';
+import { Library } from './components/Library';
 import { useDeck } from './hooks/useDeck';
 
 // Lazy-loaded components — only for views the user navigates to AFTER initial render
@@ -17,7 +18,8 @@ const AudioPlayer = lazy(() => import('./components/AudioPlayer').then(m => ({ d
 const TranscriptPanel = lazy(() => import('./components/TranscriptPanel').then(m => ({ default: m.TranscriptPanel })));
 import { useAuth } from './hooks/useAuth';
 import { useSubscription } from './hooks/useSubscription';
-import { apiRequest, subscribeToProgress, getSession, getChunk, downloadChunk, loadMoreChunks, deleteAccount, loadDemo } from './services/api';
+import { apiRequest, subscribeToProgress, getSession, getChunk, downloadChunk, loadMoreChunks, deleteAccount, loadDemo, fetchLibrary, openLibraryItem } from './services/api';
+import type { LibraryItem } from './services/api';
 import type {
   TranslatorConfig,
   AppView,
@@ -233,6 +235,16 @@ function App() {
         // Non-critical feature, silently ignore
       });
   }, []);
+
+  // Fetch content library when authenticated
+  useEffect(() => {
+    if (!userId) return;
+    setIsLoadingLibrary(true);
+    fetchLibrary()
+      .then(setLibraryItems)
+      .catch(() => { /* Non-critical, silently ignore */ })
+      .finally(() => setIsLoadingLibrary(false));
+  }, [userId]);
 
   // Clear transient overlays when URL changes (e.g., browser back/forward)
   useEffect(() => {
@@ -684,6 +696,10 @@ function App() {
 
   const [isDemoLoading, setIsDemoLoading] = useState(false);
 
+  // Library state
+  const [libraryItems, setLibraryItems] = useState<LibraryItem[]>([]);
+  const [isLoadingLibrary, setIsLoadingLibrary] = useState(false);
+
   const handleLoadDemo = useCallback(async (type: 'video' | 'text') => {
     setContentType(type);
     contentTypeRef.current = type;
@@ -714,6 +730,42 @@ function App() {
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load demo');
+      navigate('/', { replace: true });
+    } finally {
+      setIsDemoLoading(false);
+    }
+  }, [handleSelectVideoChunk, handleSelectTextChunk, navigate]);
+
+  const handleOpenLibraryItem = useCallback(async (item: LibraryItem) => {
+    setContentType(item.contentType);
+    contentTypeRef.current = item.contentType;
+    setError(null);
+    setIsDemoLoading(true);
+
+    try {
+      const response = await openLibraryItem(item.sessionId);
+      const newSessionId = response.sessionId;
+      setSessionId(newSessionId);
+      setSessionTitle(response.title);
+      setSessionTotalDuration(response.totalDuration);
+      setHasMoreChunks(response.hasMoreChunks);
+      setOriginalUrl('');
+
+      const chunksWithStatus = response.chunks.map(c => ({
+        ...c,
+        status: c.status || 'pending' as const,
+        videoUrl: c.videoUrl || null,
+      }));
+      setSessionChunks(chunksWithStatus);
+
+      if (chunksWithStatus.length === 1 && !response.hasMoreChunks) {
+        const handler = item.contentType === 'text' ? handleSelectTextChunk : handleSelectVideoChunk;
+        setTimeout(() => handler(chunksWithStatus[0], newSessionId), 0);
+      } else {
+        navigate('/chunks');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to open library item');
       navigate('/', { replace: true });
     } finally {
       setIsDemoLoading(false);
@@ -920,6 +972,13 @@ function App() {
                 </button>
               </div>
             </div>
+
+            {/* Content Library */}
+            <Library
+              items={libraryItems}
+              isLoading={isLoadingLibrary}
+              onOpenItem={handleOpenLibraryItem}
+            />
           </div>
         )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -695,6 +695,7 @@ function App() {
   }, [signOut]);
 
   const [isDemoLoading, setIsDemoLoading] = useState(false);
+  const [isLibraryItemLoading, setIsLibraryItemLoading] = useState(false);
 
   // Library state
   const [libraryItems, setLibraryItems] = useState<LibraryItem[]>([]);
@@ -740,7 +741,7 @@ function App() {
     setContentType(item.contentType);
     contentTypeRef.current = item.contentType;
     setError(null);
-    setIsDemoLoading(true);
+    setIsLibraryItemLoading(true);
 
     try {
       const response = await openLibraryItem(item.sessionId);
@@ -768,7 +769,7 @@ function App() {
       setError(err instanceof Error ? err.message : 'Failed to open library item');
       navigate('/', { replace: true });
     } finally {
-      setIsDemoLoading(false);
+      setIsLibraryItemLoading(false);
     }
   }, [handleSelectVideoChunk, handleSelectTextChunk, navigate]);
 
@@ -977,6 +978,7 @@ function App() {
             <Library
               items={libraryItems}
               isLoading={isLoadingLibrary}
+              isItemLoading={isLibraryItemLoading}
               onOpenItem={handleOpenLibraryItem}
             />
           </div>

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -3,6 +3,7 @@ import type { LibraryItem } from '../services/api';
 interface LibraryProps {
   items: LibraryItem[];
   isLoading: boolean;
+  isItemLoading: boolean;
   onOpenItem: (item: LibraryItem) => void;
 }
 
@@ -31,7 +32,7 @@ function formatDuration(seconds: number): string {
   return remMins > 0 ? `${hrs}h ${remMins}m` : `${hrs}h`;
 }
 
-export function Library({ items, isLoading, onOpenItem }: LibraryProps) {
+export function Library({ items, isLoading, isItemLoading, onOpenItem }: LibraryProps) {
   if (isLoading) {
     return (
       <div className="max-w-2xl mx-auto mt-8">
@@ -43,7 +44,14 @@ export function Library({ items, isLoading, onOpenItem }: LibraryProps) {
     );
   }
 
-  if (items.length === 0) return null;
+  if (items.length === 0) {
+    return (
+      <div className="max-w-2xl mx-auto mt-8">
+        <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-4">Content Library</h3>
+        <p className="text-center text-sm text-gray-400 py-6">No content yet. Analyze a video or text to build the library.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-2xl mx-auto mt-8">
@@ -53,7 +61,8 @@ export function Library({ items, isLoading, onOpenItem }: LibraryProps) {
           <button
             key={item.sessionId}
             onClick={() => onOpenItem(item)}
-            className="text-left p-4 rounded-lg border border-gray-200 bg-white hover:border-blue-300 hover:shadow-md transition-all"
+            disabled={isItemLoading}
+            className="text-left p-4 rounded-lg border border-gray-200 bg-white hover:border-blue-300 hover:shadow-md transition-all disabled:opacity-50 disabled:cursor-wait"
           >
             <div className="flex items-start justify-between gap-2 mb-1">
               <span className="text-sm font-medium text-gray-900 line-clamp-1">{item.title}</span>

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -1,0 +1,89 @@
+import type { LibraryItem } from '../services/api';
+
+interface LibraryProps {
+  items: LibraryItem[];
+  isLoading: boolean;
+  onOpenItem: (item: LibraryItem) => void;
+}
+
+function formatRelativeDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHr = Math.floor(diffMs / 3_600_000);
+  const diffDay = Math.floor(diffMs / 86_400_000);
+
+  if (diffMin < 1) return 'Just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay === 1) return 'Yesterday';
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}
+
+function formatDuration(seconds: number): string {
+  if (!seconds) return '';
+  const mins = Math.floor(seconds / 60);
+  if (mins < 60) return `${mins} min`;
+  const hrs = Math.floor(mins / 60);
+  const remMins = mins % 60;
+  return remMins > 0 ? `${hrs}h ${remMins}m` : `${hrs}h`;
+}
+
+export function Library({ items, isLoading, onOpenItem }: LibraryProps) {
+  if (isLoading) {
+    return (
+      <div className="max-w-2xl mx-auto mt-8">
+        <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-4">Content Library</h3>
+        <div className="flex justify-center py-6">
+          <div className="inline-block animate-spin rounded-full h-6 w-6 border-2 border-blue-500 border-t-transparent"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="max-w-2xl mx-auto mt-8">
+      <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-4">Content Library</h3>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {items.map((item) => (
+          <button
+            key={item.sessionId}
+            onClick={() => onOpenItem(item)}
+            className="text-left p-4 rounded-lg border border-gray-200 bg-white hover:border-blue-300 hover:shadow-md transition-all"
+          >
+            <div className="flex items-start justify-between gap-2 mb-1">
+              <span className="text-sm font-medium text-gray-900 line-clamp-1">{item.title}</span>
+              <span className={`shrink-0 text-xs px-1.5 py-0.5 rounded-full font-medium ${
+                item.contentType === 'video'
+                  ? 'bg-purple-100 text-purple-700'
+                  : 'bg-emerald-100 text-emerald-700'
+              }`}>
+                {item.contentType === 'video' ? 'Video' : 'Text'}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-gray-500">
+              <span>{item.chunkCount} {item.contentType === 'text' ? 'sections' : 'parts'}</span>
+              {item.contentType === 'video' && item.totalDuration > 0 && (
+                <>
+                  <span className="text-gray-300">&middot;</span>
+                  <span>{formatDuration(item.totalDuration)}</span>
+                </>
+              )}
+              {item.hasMoreChunks && (
+                <>
+                  <span className="text-gray-300">&middot;</span>
+                  <span className="text-blue-600">More available</span>
+                </>
+              )}
+              <span className="ml-auto">{formatRelativeDate(item.createdAt)}</span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -389,7 +389,6 @@ export interface LibraryItem {
   sessionId: string;
   title: string;
   contentType: 'video' | 'text';
-  url: string;
   chunkCount: number;
   totalDuration: number;
   hasMoreChunks: boolean;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -382,3 +382,35 @@ export async function createPortalSession(): Promise<{ url: string }> {
     method: 'POST',
   });
 }
+
+// ── Library ───────────────────────────────────────────────────────────
+
+export interface LibraryItem {
+  sessionId: string;
+  title: string;
+  contentType: 'video' | 'text';
+  url: string;
+  chunkCount: number;
+  totalDuration: number;
+  hasMoreChunks: boolean;
+  createdAt: string;
+}
+
+/**
+ * Fetch the content library (all cached sessions across all users).
+ */
+export async function fetchLibrary(): Promise<LibraryItem[]> {
+  const data = await apiRequest<{ items: LibraryItem[] }>('/api/library');
+  return data.items;
+}
+
+/**
+ * Open a library item by cloning the source session for the current user.
+ * Returns the same shape as a demo/cached response.
+ */
+export async function openLibraryItem(sourceSessionId: string): Promise<DemoResponse> {
+  return apiRequest<DemoResponse>('/api/library/open', {
+    method: 'POST',
+    body: JSON.stringify({ sourceSessionId }),
+  });
+}

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -108,6 +108,10 @@ vi.mock('../src/services/api', () => ({
   getChunk: vi.fn(),
   downloadChunk: vi.fn(),
   loadMoreChunks: vi.fn(),
+  deleteAccount: vi.fn().mockResolvedValue({ success: true }),
+  loadDemo: vi.fn(),
+  fetchLibrary: vi.fn().mockResolvedValue([]),
+  openLibraryItem: vi.fn(),
   getSubscription: vi.fn().mockResolvedValue({
     status: 'trialing',
     trialEnd: new Date(Date.now() + 25 * 24 * 60 * 60 * 1000).toISOString(),


### PR DESCRIPTION
## Summary
- **Content Library**: New browseable index of all cached sessions across all users, deduplicated by URL. Card grid on landing page shows title, content type, chunk count, and relative date. Click to instantly open (session cloning with re-signed GCS URLs — zero storage cost).
- **Demo Load More**: Video demo now stores full transcript + `nextBatchStartTime` so the existing load-more pipeline works seamlessly. Text demo stores `rawText` for on-demand chunking — all sections visible upfront, TTS generated per-click.
- **Demo persistence**: Demo sessions now persist to GCS (was in-memory only) so both load-more and library features work.
- **generate-demo.js**: Added `--max-chunks`, `--resume` flags and segmented audio download for robustness.

### New files
- `server/storage/library-index.js` — In-memory library index
- `src/components/Library.tsx` — Library card grid component

### New endpoints
- `GET /api/library` — Browse all cached sessions
- `POST /api/library/open` — Clone a session for the current user

## Test plan
- [ ] All unit tests pass (296/296)
- [ ] Lint clean
- [ ] Build succeeds
- [ ] Load demo video → 5 chunks shown, "Load More Parts" button visible
- [ ] Click Load More → new chunks appear from ok.ru
- [ ] Load demo text → all chunks visible, first N ready, rest pending
- [ ] Library section appears on landing page with cached content
- [ ] Click library item → chunks load instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)