### PR TITLE
Add daily streak tracking and fix stale content library

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -6,6 +6,11 @@ service cloud.firestore {
       allow write: if request.auth != null && request.auth.uid == userId
         && request.resource.data.cards is list;
     }
+    match /streaks/{userId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow write: if request.auth != null && request.auth.uid == userId
+        && request.resource.data.completionDates is list;
+    }
     match /usage/{userId} {
       allow read: if request.auth != null && request.auth.uid == userId;
       allow delete: if request.auth != null && request.auth.uid == userId;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -713,7 +713,7 @@ function App() {
   }, [signOut]);
 
   const [isDemoLoading, setIsDemoLoading] = useState(false);
-  const [isLibraryItemLoading, setIsLibraryItemLoading] = useState(false);
+  const [loadingLibraryItemId, setLoadingLibraryItemId] = useState<string | null>(null);
 
   // Library state
   const [libraryItems, setLibraryItems] = useState<LibraryItem[]>([]);
@@ -759,7 +759,7 @@ function App() {
     setContentType(item.contentType);
     contentTypeRef.current = item.contentType;
     setError(null);
-    setIsLibraryItemLoading(true);
+    setLoadingLibraryItemId(item.sessionId);
 
     try {
       const response = await openLibraryItem(item.sessionId);
@@ -787,7 +787,7 @@ function App() {
       setError(err instanceof Error ? err.message : 'Failed to open library item');
       navigate('/', { replace: true });
     } finally {
-      setIsLibraryItemLoading(false);
+      setLoadingLibraryItemId(null);
     }
   }, [handleSelectVideoChunk, handleSelectTextChunk, navigate]);
 
@@ -1004,7 +1004,7 @@ function App() {
             <Library
               items={libraryItems}
               isLoading={isLoadingLibrary}
-              isItemLoading={isLibraryItemLoading}
+              loadingItemId={loadingLibraryItemId}
               onOpenItem={handleOpenLibraryItem}
             />
           </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,13 @@ import { TextInput } from './components/TextInput';
 import { ChunkMenu } from './components/ChunkMenu';
 import { ProgressBar } from './components/ProgressBar';
 import { DeckBadge } from './components/DeckBadge';
+import { StreakBadge } from './components/StreakBadge';
 import { LandingPage } from './components/LandingPage';
 import { PaywallScreen } from './components/PaywallScreen';
 import { Library } from './components/Library';
 import { useDeck } from './hooks/useDeck';
+import { useStreak } from './hooks/useStreak';
+import { useCompletionDetector } from './hooks/useCompletionDetector';
 
 // Lazy-loaded components — only for views the user navigates to AFTER initial render
 const SettingsPanel = lazy(() => import('./components/SettingsPanel').then(m => ({ default: m.SettingsPanel })));
@@ -187,7 +190,15 @@ function App() {
   const { userId, user, isLoading: authLoading, authError, signInWithGoogle, signOut } = useAuth();
   const { subscription, isLoading: subLoading, needsPayment, handleSubscribe, handleManageSubscription, refetch: refetchSubscription } = useSubscription(userId);
   const { cards, dueCards, dueCount, addCard, removeCard, reviewCard, isWordInDeck, saveError, clearSaveError } = useDeck(userId);
+  const { currentStreak, completedToday, freezesRemaining, recordCompletion } = useStreak(userId);
+  const { handleTimeUpdate: handlePlaybackTime, reset: resetCompletion } = useCompletionDetector(transcript, recordCompletion);
   const [isReviewOpen, setIsReviewOpen] = useState(false);
+
+  // Wrapped time update: feeds both currentTime state and completion detector
+  const handleTimeUpdate = useCallback((time: number) => {
+    setCurrentTime(time);
+    handlePlaybackTime(time);
+  }, [handlePlaybackTime]);
 
   // Word frequency data
   const [wordFrequencies, setWordFrequencies] = useState<Map<string, number>>(new Map());
@@ -236,8 +247,8 @@ function App() {
       });
   }, []);
 
-  // Fetch content library when authenticated
-  useEffect(() => {
+  // Refresh library (called on mount and after returning to input view)
+  const refreshLibrary = useCallback(() => {
     if (!userId) return;
     setIsLoadingLibrary(true);
     fetchLibrary()
@@ -245,6 +256,11 @@ function App() {
       .catch(() => { /* Non-critical, silently ignore */ })
       .finally(() => setIsLoadingLibrary(false));
   }, [userId]);
+
+  // Fetch content library when authenticated
+  useEffect(() => {
+    refreshLibrary();
+  }, [refreshLibrary]);
 
   // Clear transient overlays when URL changes (e.g., browser back/forward)
   useEffect(() => {
@@ -280,12 +296,13 @@ function App() {
       setVideoTitle(data.title);
       setCurrentTime(0);
       setCurrentChunkIndex(chunk.index);
+      resetCompletion();
       navigate('/player');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load chunk');
       navigate('/chunks', { replace: true });
     }
-  }, [navigate]);
+  }, [navigate, resetCompletion]);
 
   // Shared: after a chunk finishes downloading, update state and show player
   const finishChunkDownload = useCallback((chunk: VideoChunk, data: { videoUrl?: string; audioUrl?: string; transcript: any; title: string }) => {
@@ -302,10 +319,11 @@ function App() {
     setVideoTitle(data.title);
     setCurrentTime(0);
     setCurrentChunkIndex(chunk.index);
+    resetCompletion();
     navigate('/player');
     setTransientView(null);
     setProgress([]);
-  }, [navigate]);
+  }, [navigate, resetCompletion]);
 
   const handleSelectVideoChunk = useCallback(async (chunk: VideoChunk, sessionIdOverride?: string) => {
     const activeSessionId = sessionIdOverride || sessionId;
@@ -803,7 +821,10 @@ function App() {
     setLoadingChunkIndex(null);
     setError(null);
     setProgress([]);
-  }, [navigate]);
+
+    // Refresh library so newly analyzed content appears
+    refreshLibrary();
+  }, [navigate, refreshLibrary]);
 
   // Show LandingPage immediately during auth loading AND when not logged in.
   // No spinner — user sees real content instantly instead of waiting for
@@ -857,6 +878,11 @@ function App() {
             Russian Video & Text
           </h1>
           <div className="flex items-center gap-1">
+          <StreakBadge
+            currentStreak={currentStreak}
+            completedToday={completedToday}
+            freezesRemaining={freezesRemaining}
+          />
           <DeckBadge
             dueCount={dueCount}
             totalCount={cards.length}
@@ -1139,7 +1165,7 @@ function App() {
             {contentType === 'text' && audioUrl && (
               <Suspense fallback={<div className="flex justify-center py-12"><div className="inline-block animate-spin rounded-full h-10 w-10 border-4 border-blue-500 border-t-transparent"></div></div>}>
               <div className="space-y-4">
-                <AudioPlayer url={audioUrl} onTimeUpdate={setCurrentTime} />
+                <AudioPlayer url={audioUrl} onTimeUpdate={handleTimeUpdate} />
                 <div className="bg-white rounded-lg shadow-sm">
                   <div className="p-3 border-b bg-gray-50 rounded-t-lg">
                     <h3 className="font-medium text-gray-700">Text</h3>
@@ -1168,7 +1194,7 @@ function App() {
                   <VideoPlayer
                     url={videoUrl}
                     originalUrl={originalUrl}
-                    onTimeUpdate={setCurrentTime}
+                    onTimeUpdate={handleTimeUpdate}
                   />
                 </div>
                 <div className="bg-white rounded-lg shadow-sm">

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -7,22 +7,6 @@ interface LibraryProps {
   onOpenItem: (item: LibraryItem) => void;
 }
 
-function formatRelativeDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  const now = Date.now();
-  const diffMs = now - date.getTime();
-  const diffMin = Math.floor(diffMs / 60_000);
-  const diffHr = Math.floor(diffMs / 3_600_000);
-  const diffDay = Math.floor(diffMs / 86_400_000);
-
-  if (diffMin < 1) return 'Just now';
-  if (diffMin < 60) return `${diffMin}m ago`;
-  if (diffHr < 24) return `${diffHr}h ago`;
-  if (diffDay === 1) return 'Yesterday';
-  if (diffDay < 7) return `${diffDay}d ago`;
-  return date.toLocaleDateString();
-}
-
 function formatDuration(seconds: number): string {
   if (!seconds) return '';
   const mins = Math.floor(seconds / 60);
@@ -32,66 +16,82 @@ function formatDuration(seconds: number): string {
   return remMins > 0 ? `${hrs}h ${remMins}m` : `${hrs}h`;
 }
 
+/** Truncate title to fit in a button, preserving whole words. */
+function truncateTitle(title: string, maxLen = 40): string {
+  if (title.length <= maxLen) return title;
+  const truncated = title.slice(0, maxLen).replace(/\s+\S*$/, '');
+  return truncated + '...';
+}
+
 export function Library({ items, isLoading, isItemLoading, onOpenItem }: LibraryProps) {
+  // Find most recent video and most recent text (items are sorted by createdAt desc)
+  const latestVideo = items.find(i => i.contentType === 'video') ?? null;
+  const latestText = items.find(i => i.contentType === 'text') ?? null;
+
   if (isLoading) {
-    return (
-      <div className="max-w-2xl mx-auto mt-8">
-        <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-4">Content Library</h3>
-        <div className="flex justify-center py-6">
-          <div className="inline-block animate-spin rounded-full h-6 w-6 border-2 border-blue-500 border-t-transparent"></div>
-        </div>
-      </div>
-    );
+    return null; // Don't show anything while loading — avoids layout shift
   }
 
-  if (items.length === 0) {
-    return (
-      <div className="max-w-2xl mx-auto mt-8">
-        <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-4">Content Library</h3>
-        <p className="text-center text-sm text-gray-400 py-6">No content yet. Analyze a video or text to build the library.</p>
-      </div>
-    );
+  if (!latestVideo && !latestText) {
+    return null; // Nothing to show
   }
 
   return (
-    <div className="max-w-2xl mx-auto mt-8">
-      <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-4">Content Library</h3>
-      <div className="grid gap-3 sm:grid-cols-2">
-        {items.map((item) => (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center gap-4 my-6">
+        <div className="flex-1 border-t border-gray-300"></div>
+        <span className="text-sm text-gray-500">or continue where you left off</span>
+        <div className="flex-1 border-t border-gray-300"></div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {latestVideo && (
           <button
-            key={item.sessionId}
-            onClick={() => onOpenItem(item)}
+            data-testid="cached-video-btn"
+            onClick={() => onOpenItem(latestVideo)}
             disabled={isItemLoading}
-            className="text-left p-4 rounded-lg border border-gray-200 bg-white hover:border-blue-300 hover:shadow-md transition-all disabled:opacity-50 disabled:cursor-wait"
+            className="px-4 py-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:border-purple-400 transition-colors text-sm text-gray-700 disabled:opacity-50 disabled:cursor-wait text-left"
           >
-            <div className="flex items-start justify-between gap-2 mb-1">
-              <span className="text-sm font-medium text-gray-900 line-clamp-1">{item.title}</span>
-              <span className={`shrink-0 text-xs px-1.5 py-0.5 rounded-full font-medium ${
-                item.contentType === 'video'
-                  ? 'bg-purple-100 text-purple-700'
-                  : 'bg-emerald-100 text-emerald-700'
-              }`}>
-                {item.contentType === 'video' ? 'Video' : 'Text'}
+            {isItemLoading ? (
+              <span className="flex items-center justify-center gap-2">
+                <span className="inline-block animate-spin rounded-full h-4 w-4 border-2 border-purple-500 border-t-transparent"></span>
+                Loading...
               </span>
-            </div>
-            <div className="flex items-center gap-2 text-xs text-gray-500">
-              <span>{item.chunkCount} {item.contentType === 'text' ? 'sections' : 'parts'}</span>
-              {item.contentType === 'video' && item.totalDuration > 0 && (
-                <>
-                  <span className="text-gray-300">&middot;</span>
-                  <span>{formatDuration(item.totalDuration)}</span>
-                </>
-              )}
-              {item.hasMoreChunks && (
-                <>
-                  <span className="text-gray-300">&middot;</span>
-                  <span className="text-blue-600">More available</span>
-                </>
-              )}
-              <span className="ml-auto">{formatRelativeDate(item.createdAt)}</span>
-            </div>
+            ) : (
+              <div>
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-xs px-1.5 py-0.5 rounded-full font-medium bg-purple-100 text-purple-700">Video</span>
+                  {latestVideo.totalDuration > 0 && (
+                    <span className="text-xs text-gray-400">{formatDuration(latestVideo.totalDuration)}</span>
+                  )}
+                </div>
+                <span className="font-medium text-gray-900 line-clamp-1">{truncateTitle(latestVideo.title)}</span>
+              </div>
+            )}
           </button>
-        ))}
+        )}
+        {latestText && (
+          <button
+            data-testid="cached-text-btn"
+            onClick={() => onOpenItem(latestText)}
+            disabled={isItemLoading}
+            className="px-4 py-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:border-emerald-400 transition-colors text-sm text-gray-700 disabled:opacity-50 disabled:cursor-wait text-left"
+          >
+            {isItemLoading ? (
+              <span className="flex items-center justify-center gap-2">
+                <span className="inline-block animate-spin rounded-full h-4 w-4 border-2 border-emerald-500 border-t-transparent"></span>
+                Loading...
+              </span>
+            ) : (
+              <div>
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-xs px-1.5 py-0.5 rounded-full font-medium bg-emerald-100 text-emerald-700">Text</span>
+                  <span className="text-xs text-gray-400">{latestText.chunkCount} sections</span>
+                </div>
+                <span className="font-medium text-gray-900 line-clamp-1">{truncateTitle(latestText.title)}</span>
+              </div>
+            )}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -3,7 +3,7 @@ import type { LibraryItem } from '../services/api';
 interface LibraryProps {
   items: LibraryItem[];
   isLoading: boolean;
-  isItemLoading: boolean;
+  loadingItemId: string | null;
   onOpenItem: (item: LibraryItem) => void;
 }
 
@@ -20,10 +20,10 @@ function formatDuration(seconds: number): string {
 function truncateTitle(title: string, maxLen = 40): string {
   if (title.length <= maxLen) return title;
   const truncated = title.slice(0, maxLen).replace(/\s+\S*$/, '');
-  return truncated + '...';
+  return (truncated || title.slice(0, maxLen)) + '...';
 }
 
-export function Library({ items, isLoading, isItemLoading, onOpenItem }: LibraryProps) {
+export function Library({ items, isLoading, loadingItemId, onOpenItem }: LibraryProps) {
   // Find most recent video and most recent text (items are sorted by createdAt desc)
   const latestVideo = items.find(i => i.contentType === 'video') ?? null;
   const latestText = items.find(i => i.contentType === 'text') ?? null;
@@ -48,10 +48,10 @@ export function Library({ items, isLoading, isItemLoading, onOpenItem }: Library
           <button
             data-testid="cached-video-btn"
             onClick={() => onOpenItem(latestVideo)}
-            disabled={isItemLoading}
+            disabled={loadingItemId !== null}
             className="px-4 py-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:border-purple-400 transition-colors text-sm text-gray-700 disabled:opacity-50 disabled:cursor-wait text-left"
           >
-            {isItemLoading ? (
+            {loadingItemId === latestVideo.sessionId ? (
               <span className="flex items-center justify-center gap-2">
                 <span className="inline-block animate-spin rounded-full h-4 w-4 border-2 border-purple-500 border-t-transparent"></span>
                 Loading...
@@ -73,10 +73,10 @@ export function Library({ items, isLoading, isItemLoading, onOpenItem }: Library
           <button
             data-testid="cached-text-btn"
             onClick={() => onOpenItem(latestText)}
-            disabled={isItemLoading}
+            disabled={loadingItemId !== null}
             className="px-4 py-3 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:border-emerald-400 transition-colors text-sm text-gray-700 disabled:opacity-50 disabled:cursor-wait text-left"
           >
-            {isItemLoading ? (
+            {loadingItemId === latestText.sessionId ? (
               <span className="flex items-center justify-center gap-2">
                 <span className="inline-block animate-spin rounded-full h-4 w-4 border-2 border-emerald-500 border-t-transparent"></span>
                 Loading...

--- a/src/components/StreakBadge.tsx
+++ b/src/components/StreakBadge.tsx
@@ -10,7 +10,7 @@ export function StreakBadge({ currentStreak, completedToday, freezesRemaining }:
     tooltipParts.push(`${currentStreak} day streak`);
   }
   if (!completedToday) {
-    tooltipParts.push('Complete a chunk to extend!');
+    tooltipParts.push(currentStreak > 0 ? 'Complete a chunk to extend!' : 'Complete a chunk to start a streak!');
   } else {
     tooltipParts.push("Today's goal complete!");
   }

--- a/src/components/StreakBadge.tsx
+++ b/src/components/StreakBadge.tsx
@@ -1,0 +1,56 @@
+interface StreakBadgeProps {
+  currentStreak: number;
+  completedToday: boolean;
+  freezesRemaining: number;
+}
+
+export function StreakBadge({ currentStreak, completedToday, freezesRemaining }: StreakBadgeProps) {
+  const tooltipParts: string[] = [];
+  if (currentStreak > 0) {
+    tooltipParts.push(`${currentStreak} day streak`);
+  }
+  if (!completedToday) {
+    tooltipParts.push('Complete a chunk to extend!');
+  } else {
+    tooltipParts.push("Today's goal complete!");
+  }
+  tooltipParts.push(`${freezesRemaining} freeze${freezesRemaining !== 1 ? 's' : ''} remaining`);
+  const tooltip = tooltipParts.join(' — ');
+
+  return (
+    <div
+      className="flex items-center gap-1 px-2 py-1 rounded-md"
+      title={tooltip}
+      data-testid="streak-badge"
+    >
+      {/* Flame icon */}
+      <svg
+        className={`w-5 h-5 ${completedToday ? 'text-orange-500' : 'text-gray-400'}`}
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        data-testid="streak-flame"
+      >
+        <path d="M12 23c-3.6 0-7-2.4-7-7 0-3.1 2.1-5.7 3.2-6.8.4-.4 1-.2 1.2.3.6 1.7 1.8 3 2.8 3.7.2-.8.3-2.1-.2-3.7-.2-.5.1-1.1.6-1.2.5-.1 1 .1 1.2.5C15.6 12.1 19 14.5 19 16c0 4.6-3.4 7-7 7z" />
+      </svg>
+      {/* Streak count */}
+      <span
+        className={`text-sm font-semibold tabular-nums ${completedToday ? 'text-orange-600' : 'text-gray-500'}`}
+        data-testid="streak-count"
+      >
+        {currentStreak}
+      </span>
+      {/* Freeze dots */}
+      <div className="flex gap-0.5 ml-0.5" data-testid="freeze-dots">
+        {[0, 1].map(i => (
+          <div
+            key={i}
+            className={`w-1.5 h-1.5 rounded-full ${
+              i < freezesRemaining ? 'bg-blue-400' : 'bg-gray-300'
+            }`}
+            data-testid={`freeze-dot-${i}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useCompletionDetector.ts
+++ b/src/hooks/useCompletionDetector.ts
@@ -15,6 +15,8 @@ export function useCompletionDetector(
   const lastTimeRef = useRef<number | null>(null);
   const playedTimeRef = useRef(0);
   const firedRef = useRef(false);
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
 
   const handleTimeUpdate = useCallback((time: number) => {
     if (!transcript || firedRef.current) return;
@@ -34,10 +36,10 @@ export function useCompletionDetector(
 
       if (playedTimeRef.current >= transcript.duration * 0.5) {
         firedRef.current = true;
-        onComplete();
+        onCompleteRef.current();
       }
     }
-  }, [transcript, onComplete]);
+  }, [transcript]);
 
   const reset = useCallback(() => {
     lastTimeRef.current = null;

--- a/src/hooks/useCompletionDetector.ts
+++ b/src/hooks/useCompletionDetector.ts
@@ -1,4 +1,4 @@
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import type { Transcript } from '../types';
 
 /**
@@ -16,7 +16,7 @@ export function useCompletionDetector(
   const playedTimeRef = useRef(0);
   const firedRef = useRef(false);
   const onCompleteRef = useRef(onComplete);
-  onCompleteRef.current = onComplete;
+  useEffect(() => { onCompleteRef.current = onComplete; });
 
   const handleTimeUpdate = useCallback((time: number) => {
     if (!transcript || firedRef.current) return;

--- a/src/hooks/useCompletionDetector.ts
+++ b/src/hooks/useCompletionDetector.ts
@@ -1,0 +1,49 @@
+import { useRef, useCallback } from 'react';
+import type { Transcript } from '../types';
+
+/**
+ * Tracks cumulative play time via delta accumulation.
+ * Fires `onComplete` once when playedTime >= 50% of transcript duration.
+ *
+ * Delta-based: only normal forward playback (small positive deltas) accumulates.
+ * Seeks (large jumps), pauses (no ticks), and backward seeks are all rejected.
+ */
+export function useCompletionDetector(
+  transcript: Transcript | null,
+  onComplete: () => void,
+): { handleTimeUpdate: (time: number) => void; reset: () => void } {
+  const lastTimeRef = useRef<number | null>(null);
+  const playedTimeRef = useRef(0);
+  const firedRef = useRef(false);
+
+  const handleTimeUpdate = useCallback((time: number) => {
+    if (!transcript || firedRef.current) return;
+
+    const lastTime = lastTimeRef.current;
+    lastTimeRef.current = time;
+
+    if (lastTime === null) return;
+
+    const delta = time - lastTime;
+
+    // Only count normal forward playback: 0 < delta < 0.5s
+    // Player ticks every 100ms, so normal delta ≈ 0.1s
+    // Rejects: seeks (delta > 0.5), backward seeks (delta < 0), pauses (delta ≈ 0)
+    if (delta > 0 && delta < 0.5) {
+      playedTimeRef.current += delta;
+
+      if (playedTimeRef.current >= transcript.duration * 0.5) {
+        firedRef.current = true;
+        onComplete();
+      }
+    }
+  }, [transcript, onComplete]);
+
+  const reset = useCallback(() => {
+    lastTimeRef.current = null;
+    playedTimeRef.current = 0;
+    firedRef.current = false;
+  }, []);
+
+  return { handleTimeUpdate, reset };
+}

--- a/src/hooks/useStreak.ts
+++ b/src/hooks/useStreak.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import type { StreakData } from '../types';
 import { getLocalDateString, computeStreakState } from '../utils/streak';
 import {
@@ -68,12 +68,11 @@ export function useStreak(userId: string | null) {
     return () => { signal.cancelled = true; };
   }, [userId]);
 
-  // Compute derived state on every render
+  // Compute derived state (memoized to avoid recomputing on unrelated re-renders)
   const today = getLocalDateString();
-  const state = computeStreakState(
-    streakData.completionDates,
-    streakData.longestStreak,
-    today,
+  const state = useMemo(
+    () => computeStreakState(streakData.completionDates, streakData.longestStreak, today),
+    [streakData.completionDates, streakData.longestStreak, today],
   );
 
   const recordCompletion = useCallback(() => {

--- a/src/hooks/useStreak.ts
+++ b/src/hooks/useStreak.ts
@@ -1,0 +1,114 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { StreakData } from '../types';
+import { getLocalDateString, computeStreakState } from '../utils/streak';
+import {
+  loadLocalStreak,
+  loadFromFirestore,
+  createDebouncedSave,
+} from '../services/streak-persistence';
+
+const MAX_COMPLETION_DATES = 90;
+
+export function useStreak(userId: string | null) {
+  const [streakData, setStreakData] = useState<StreakData>({
+    currentStreak: 0,
+    longestStreak: 0,
+    completionDates: [],
+    freezesUsedThisWeek: 0,
+    freezeWeekStart: '',
+    lastCompletionDate: null,
+  });
+  const [loaded, setLoaded] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const loadedUserRef = useRef<string | null>(null);
+  const saverRef = useRef<{ save: (data: StreakData) => void; cleanup: () => void } | null>(null);
+
+  // Create/replace debounced saver when userId changes
+  useEffect(() => {
+    if (saverRef.current) saverRef.current.cleanup();
+    if (!userId) {
+      saverRef.current = null;
+      return;
+    }
+    saverRef.current = createDebouncedSave(
+      userId,
+      () => setSaveError(null),
+      (msg) => setSaveError(msg),
+    );
+    return () => {
+      if (saverRef.current) saverRef.current.cleanup();
+    };
+  }, [userId]);
+
+  const saveToFirestore = useCallback((data: StreakData) => {
+    saverRef.current?.save(data);
+  }, []);
+
+  // Load from Firestore when userId becomes available
+  useEffect(() => {
+    if (!userId || loadedUserRef.current === userId) return;
+
+    const signal = { cancelled: false };
+
+    async function load() {
+      let data: StreakData;
+      try {
+        data = await loadFromFirestore(userId!);
+      } catch {
+        data = loadLocalStreak();
+      }
+      if (!signal.cancelled) {
+        setStreakData(data);
+        loadedUserRef.current = userId;
+        setLoaded(true);
+      }
+    }
+
+    load();
+    return () => { signal.cancelled = true; };
+  }, [userId]);
+
+  // Compute derived state on every render
+  const today = getLocalDateString();
+  const state = computeStreakState(
+    streakData.completionDates,
+    streakData.longestStreak,
+    today,
+  );
+
+  const recordCompletion = useCallback(() => {
+    const todayStr = getLocalDateString();
+
+    setStreakData(prev => {
+      // Idempotent: no-op if today already recorded
+      if (prev.completionDates.includes(todayStr)) return prev;
+
+      const updatedDates = [...prev.completionDates, todayStr]
+        .slice(-MAX_COMPLETION_DATES); // trim to last 90
+
+      const newState = computeStreakState(updatedDates, prev.longestStreak, todayStr);
+
+      const next: StreakData = {
+        currentStreak: newState.currentStreak,
+        longestStreak: newState.longestStreak,
+        completionDates: updatedDates,
+        freezesUsedThisWeek: newState.freezesUsedThisWeek,
+        freezeWeekStart: newState.freezeWeekStart,
+        lastCompletionDate: todayStr,
+      };
+
+      saveToFirestore(next);
+      return next;
+    });
+  }, [saveToFirestore]);
+
+  return {
+    currentStreak: state.currentStreak,
+    longestStreak: state.longestStreak,
+    completedToday: state.completedToday,
+    freezesRemaining: 2 - state.freezesUsedThisWeek,
+    recordCompletion,
+    loaded,
+    saveError,
+  };
+}

--- a/src/services/streak-persistence.ts
+++ b/src/services/streak-persistence.ts
@@ -1,0 +1,124 @@
+/**
+ * Streak persistence layer.
+ *
+ * Handles Firestore load/save + localStorage fallback.
+ * Follows the same pattern as deck-persistence.ts.
+ */
+import * as Sentry from '@sentry/react';
+import type { StreakData } from '../types';
+
+const STREAK_KEY = 'streak_data';
+const DEBOUNCE_MS = 500;
+
+const DEFAULT_STREAK: StreakData = {
+  currentStreak: 0,
+  longestStreak: 0,
+  completionDates: [],
+  freezesUsedThisWeek: 0,
+  freezeWeekStart: '',
+  lastCompletionDate: null,
+};
+
+async function getFirestoreHelpers() {
+  const [firestoreModule, { db }] = await Promise.all([
+    import('firebase/firestore'),
+    import('../firebase-db'),
+  ]);
+  return {
+    doc: firestoreModule.doc,
+    getDoc: firestoreModule.getDoc,
+    setDoc: firestoreModule.setDoc,
+    serverTimestamp: firestoreModule.serverTimestamp,
+    db,
+  };
+}
+
+/** Load streak from localStorage (best-effort, ignores corrupt data). */
+export function loadLocalStreak(): StreakData {
+  try {
+    const saved = localStorage.getItem(STREAK_KEY);
+    if (saved) {
+      return JSON.parse(saved);
+    }
+  } catch {
+    // Ignore corrupt data
+  }
+  return { ...DEFAULT_STREAK };
+}
+
+/** Save streak to localStorage as a backup. */
+export function saveLocalBackup(data: StreakData): void {
+  try {
+    localStorage.setItem(STREAK_KEY, JSON.stringify(data));
+  } catch (err) {
+    Sentry.captureException(err, { tags: { operation: 'streak_local_backup' } });
+  }
+}
+
+/**
+ * Load streak from Firestore. If Firestore is empty, migrates localStorage data.
+ * Falls back to localStorage if Firestore is unavailable.
+ */
+export async function loadFromFirestore(userId: string): Promise<StreakData> {
+  const { doc, getDoc, setDoc, serverTimestamp, db } = await getFirestoreHelpers();
+  const streakRef = doc(db, 'streaks', userId);
+  const snap = await getDoc(streakRef);
+
+  if (snap.exists()) {
+    const data = snap.data();
+    return {
+      currentStreak: data.currentStreak ?? 0,
+      longestStreak: data.longestStreak ?? 0,
+      completionDates: data.completionDates ?? [],
+      freezesUsedThisWeek: data.freezesUsedThisWeek ?? 0,
+      freezeWeekStart: data.freezeWeekStart ?? '',
+      lastCompletionDate: data.lastCompletionDate ?? null,
+    };
+  }
+
+  // Firestore empty — check localStorage for migration
+  const local = loadLocalStreak();
+  if (local.completionDates.length > 0) {
+    await setDoc(streakRef, { ...local, updatedAt: serverTimestamp() });
+    localStorage.removeItem(STREAK_KEY);
+    return local;
+  }
+
+  return { ...DEFAULT_STREAK };
+}
+
+/**
+ * Create a debounced Firestore saver for streak data.
+ * Returns `{ save, cleanup }` — call `save(data)` after each mutation,
+ * and `cleanup()` on unmount to clear the pending timer.
+ */
+export function createDebouncedSave(
+  userId: string,
+  onSuccess: () => void,
+  onError: (msg: string) => void,
+): { save: (data: StreakData) => void; cleanup: () => void } {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function save(data: StreakData) {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(async () => {
+      try {
+        const { doc, setDoc, serverTimestamp, db } = await getFirestoreHelpers();
+        const streakRef = doc(db, 'streaks', userId);
+        await setDoc(streakRef, { ...data, updatedAt: serverTimestamp() });
+        onSuccess();
+      } catch (err) {
+        console.error('[streak-persistence] Firestore save failed:', err);
+        Sentry.captureException(err, { tags: { operation: 'streak_save' } });
+        onError('Streak data may not be saved — check your connection');
+        saveLocalBackup(data);
+      }
+    }, DEBOUNCE_MS);
+  }
+
+  function cleanup() {
+    if (timer) clearTimeout(timer);
+  }
+
+  return { save, cleanup };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,3 +141,14 @@ export interface SRSCard {
 }
 
 export type SRSRating = 0 | 2 | 4 | 5; // Again=0, Hard=2, Good=4, Easy=5
+
+// ── Streak tracking ─────────────────────────────────────────────────
+
+export interface StreakData {
+  currentStreak: number;
+  longestStreak: number;
+  completionDates: string[];         // "YYYY-MM-DD" local time, last ~90 days
+  freezesUsedThisWeek: number;       // 0, 1, or 2
+  freezeWeekStart: string;           // "YYYY-MM-DD" Monday of current tracking week
+  lastCompletionDate: string | null;
+}

--- a/src/utils/streak.ts
+++ b/src/utils/streak.ts
@@ -61,9 +61,12 @@ export function computeStreakState(
 
   // Only walk backward if there are completion dates to find
   // (avoids consuming freezes when there's no streak to preserve)
-  while (dateSet.size > 0) {
+  // Max 400 iterations (~13 months) as a safety bound against corrupted data
+  let steps = 0;
+  while (dateSet.size > 0 && steps++ < 400) {
     if (dateSet.has(cursor)) {
       streak++;
+      dateSet.delete(cursor); // shrink set so loop terminates
       cursor = previousDay(cursor);
       continue;
     }

--- a/src/utils/streak.ts
+++ b/src/utils/streak.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure streak computation — no side effects, no IO.
+ * All dates are "YYYY-MM-DD" strings in the user's local timezone.
+ */
+
+/** Returns today's date as "YYYY-MM-DD" in local timezone. */
+export function getLocalDateString(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Subtract one day from a "YYYY-MM-DD" string. Uses noon anchor to dodge DST. */
+export function previousDay(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const date = new Date(y, m - 1, d, 12); // noon anchor
+  date.setDate(date.getDate() - 1);
+  return getLocalDateString(date);
+}
+
+/** Find the Monday (ISO week start) for a given "YYYY-MM-DD". */
+export function getMondayOfWeek(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const date = new Date(y, m - 1, d, 12);
+  const day = date.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+  const diff = day === 0 ? 6 : day - 1; // days since Monday
+  date.setDate(date.getDate() - diff);
+  return getLocalDateString(date);
+}
+
+export interface StreakState {
+  currentStreak: number;
+  longestStreak: number;
+  completedToday: boolean;
+  freezesUsedThisWeek: number;
+  freezeWeekStart: string;
+}
+
+/**
+ * Compute the current streak state from completion history.
+ *
+ * Walks backward from yesterday through completionDates:
+ * - Each completed day: increment streak
+ * - Each gap within the current Mon-Sun week with freezes < 2: consume a freeze, continue
+ * - Each gap outside current week or freezes exhausted: stop
+ * - If today is completed: add 1 to streak
+ */
+export function computeStreakState(
+  completionDates: string[],
+  storedLongestStreak: number,
+  today: string = getLocalDateString(),
+): StreakState {
+  const dateSet = new Set(completionDates);
+  const completedToday = dateSet.has(today);
+  const currentWeekMonday = getMondayOfWeek(today);
+
+  let streak = 0;
+  let freezesUsed = 0;
+  let cursor = previousDay(today);
+
+  // Only walk backward if there are completion dates to find
+  // (avoids consuming freezes when there's no streak to preserve)
+  while (dateSet.size > 0) {
+    if (dateSet.has(cursor)) {
+      streak++;
+      cursor = previousDay(cursor);
+      continue;
+    }
+
+    // Gap day — can we use a freeze?
+    const cursorWeekMonday = getMondayOfWeek(cursor);
+    if (cursorWeekMonday === currentWeekMonday && freezesUsed < 2) {
+      freezesUsed++;
+      cursor = previousDay(cursor);
+      continue;
+    }
+
+    // Gap with no freeze available — streak ends
+    break;
+  }
+
+  // If today is completed, it extends the streak
+  if (completedToday) {
+    streak++;
+  }
+
+  const longestStreak = Math.max(storedLongestStreak, streak);
+
+  return {
+    currentStreak: streak,
+    longestStreak,
+    completedToday,
+    freezesUsedThisWeek: freezesUsed,
+    freezeWeekStart: currentWeekMonday,
+  };
+}

--- a/tests/completion-detection.test.ts
+++ b/tests/completion-detection.test.ts
@@ -12,7 +12,12 @@ function makeTranscript(duration: number): Transcript {
   };
 }
 
-/** Simulate playback ticks using integer math to avoid floating-point drift. */
+/**
+ * Simulate playback ticks using integer math to avoid floating-point drift.
+ * @param handler - The time update handler to call
+ * @param fromSec - Start time in seconds (ticks at 0.1s intervals)
+ * @param toSec - End time in seconds (inclusive)
+ */
 function simulateTicks(
   handler: (time: number) => void,
   fromSec: number,

--- a/tests/completion-detection.test.ts
+++ b/tests/completion-detection.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCompletionDetector } from '../src/hooks/useCompletionDetector';
+import type { Transcript } from '../src/types';
+
+function makeTranscript(duration: number): Transcript {
+  return {
+    words: [],
+    segments: [],
+    language: 'ru',
+    duration,
+  };
+}
+
+/** Simulate playback ticks using integer math to avoid floating-point drift. */
+function simulateTicks(
+  handler: (time: number) => void,
+  fromSec: number,
+  toSec: number,
+) {
+  const fromMs = Math.round(fromSec * 10);
+  const toMs = Math.round(toSec * 10);
+  for (let i = fromMs; i <= toMs; i++) {
+    handler(i / 10);
+  }
+}
+
+describe('useCompletionDetector', () => {
+  let onComplete: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onComplete = vi.fn();
+  });
+
+  it('fires onComplete when cumulative play reaches 50%', () => {
+    const transcript = makeTranscript(100); // 100 seconds, threshold = 50s
+    const { result } = renderHook(() => useCompletionDetector(transcript, onComplete));
+
+    act(() => {
+      simulateTicks(result.current.handleTimeUpdate, 0, 51);
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire before 50% threshold', () => {
+    const transcript = makeTranscript(100);
+    const { result } = renderHook(() => useCompletionDetector(transcript, onComplete));
+
+    act(() => {
+      simulateTicks(result.current.handleTimeUpdate, 0, 40);
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('rejects seek (large positive jump)', () => {
+    const transcript = makeTranscript(100);
+    const { result } = renderHook(() => useCompletionDetector(transcript, onComplete));
+
+    act(() => {
+      // Play 10 seconds normally
+      simulateTicks(result.current.handleTimeUpdate, 0, 10);
+      // Seek to 80s (jump of 70s — rejected)
+      result.current.handleTimeUpdate(80);
+      // Continue from 80 for 5 seconds
+      simulateTicks(result.current.handleTimeUpdate, 80.1, 85);
+    });
+
+    // Only ~15s of cumulative play, not 50%
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('rejects backward seek', () => {
+    const transcript = makeTranscript(100);
+    const { result } = renderHook(() => useCompletionDetector(transcript, onComplete));
+
+    act(() => {
+      simulateTicks(result.current.handleTimeUpdate, 0, 20);
+      // Seek backward to 5s
+      result.current.handleTimeUpdate(5);
+      // Continue from 5s for 15s
+      simulateTicks(result.current.handleTimeUpdate, 5.1, 20);
+    });
+
+    // ~35s cumulative, not 50% of 100s
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('accumulates across pause/resume', () => {
+    const transcript = makeTranscript(60); // 60s, need 30s
+    const { result } = renderHook(() => useCompletionDetector(transcript, onComplete));
+
+    act(() => {
+      // Play 20 seconds
+      simulateTicks(result.current.handleTimeUpdate, 0, 20);
+    });
+
+    // Simulate pause (no ticks)
+
+    act(() => {
+      // Resume — player position hasn't changed during pause
+      simulateTicks(result.current.handleTimeUpdate, 20.1, 35);
+    });
+
+    // ~35s cumulative > 30s threshold
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires only once', () => {
+    const transcript = makeTranscript(20);
+    const { result } = renderHook(() => useCompletionDetector(transcript, onComplete));
+
+    act(() => {
+      simulateTicks(result.current.handleTimeUpdate, 0, 20);
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('reset clears state for new chunk', () => {
+    const transcript = makeTranscript(20); // need 10s
+    const { result } = renderHook(() => useCompletionDetector(transcript, onComplete));
+
+    act(() => {
+      // Play 8 seconds (not enough)
+      simulateTicks(result.current.handleTimeUpdate, 0, 8);
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // Reset for new chunk
+    act(() => {
+      result.current.reset();
+    });
+
+    act(() => {
+      // Play 8 more seconds — should NOT carry over previous 8s
+      simulateTicks(result.current.handleTimeUpdate, 0, 8);
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when transcript is null', () => {
+    const { result } = renderHook(() => useCompletionDetector(null, onComplete));
+
+    act(() => {
+      simulateTicks(result.current.handleTimeUpdate, 0, 100);
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/tests/streak-badge.test.tsx
+++ b/tests/streak-badge.test.tsx
@@ -62,4 +62,11 @@ describe('StreakBadge', () => {
     render(<StreakBadge currentStreak={0} completedToday={false} freezesRemaining={2} />);
     expect(screen.getByTestId('streak-count').textContent).toBe('0');
   });
+
+  it('shows "start a streak" tooltip when streak is zero', () => {
+    render(<StreakBadge currentStreak={0} completedToday={false} freezesRemaining={2} />);
+    const badge = screen.getByTestId('streak-badge');
+    expect(badge.title).toContain('Complete a chunk to start a streak!');
+    expect(badge.title).not.toContain('extend');
+  });
 });

--- a/tests/streak-badge.test.tsx
+++ b/tests/streak-badge.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StreakBadge } from '../src/components/StreakBadge';
+
+describe('StreakBadge', () => {
+  it('renders streak count', () => {
+    render(<StreakBadge currentStreak={5} completedToday={false} freezesRemaining={2} />);
+    expect(screen.getByTestId('streak-count').textContent).toBe('5');
+  });
+
+  it('shows orange flame when completed today', () => {
+    render(<StreakBadge currentStreak={3} completedToday={true} freezesRemaining={2} />);
+    const flame = screen.getByTestId('streak-flame');
+    expect(flame.classList.contains('text-orange-500')).toBe(true);
+  });
+
+  it('shows gray flame when not completed today', () => {
+    render(<StreakBadge currentStreak={3} completedToday={false} freezesRemaining={2} />);
+    const flame = screen.getByTestId('streak-flame');
+    expect(flame.classList.contains('text-gray-400')).toBe(true);
+  });
+
+  it('shows correct freeze dots — 2 remaining', () => {
+    render(<StreakBadge currentStreak={1} completedToday={true} freezesRemaining={2} />);
+    const dot0 = screen.getByTestId('freeze-dot-0');
+    const dot1 = screen.getByTestId('freeze-dot-1');
+    expect(dot0.classList.contains('bg-blue-400')).toBe(true);
+    expect(dot1.classList.contains('bg-blue-400')).toBe(true);
+  });
+
+  it('shows correct freeze dots — 1 remaining', () => {
+    render(<StreakBadge currentStreak={1} completedToday={true} freezesRemaining={1} />);
+    const dot0 = screen.getByTestId('freeze-dot-0');
+    const dot1 = screen.getByTestId('freeze-dot-1');
+    expect(dot0.classList.contains('bg-blue-400')).toBe(true);
+    expect(dot1.classList.contains('bg-gray-300')).toBe(true);
+  });
+
+  it('shows correct freeze dots — 0 remaining', () => {
+    render(<StreakBadge currentStreak={1} completedToday={true} freezesRemaining={0} />);
+    const dot0 = screen.getByTestId('freeze-dot-0');
+    const dot1 = screen.getByTestId('freeze-dot-1');
+    expect(dot0.classList.contains('bg-gray-300')).toBe(true);
+    expect(dot1.classList.contains('bg-gray-300')).toBe(true);
+  });
+
+  it('has correct tooltip with streak', () => {
+    render(<StreakBadge currentStreak={5} completedToday={false} freezesRemaining={1} />);
+    const badge = screen.getByTestId('streak-badge');
+    expect(badge.title).toContain('5 day streak');
+    expect(badge.title).toContain('Complete a chunk to extend!');
+    expect(badge.title).toContain('1 freeze remaining');
+  });
+
+  it('has correct tooltip when completed today', () => {
+    render(<StreakBadge currentStreak={5} completedToday={true} freezesRemaining={2} />);
+    const badge = screen.getByTestId('streak-badge');
+    expect(badge.title).toContain("Today's goal complete!");
+  });
+
+  it('renders zero streak', () => {
+    render(<StreakBadge currentStreak={0} completedToday={false} freezesRemaining={2} />);
+    expect(screen.getByTestId('streak-count').textContent).toBe('0');
+  });
+});

--- a/tests/streak-persistence.test.ts
+++ b/tests/streak-persistence.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { StreakData } from '../src/types';
+
+// Mock Firebase modules
+const mockGetDoc = vi.fn();
+const mockSetDoc = vi.fn();
+const mockDoc = vi.fn(() => 'mock-ref');
+const mockServerTimestamp = vi.fn(() => 'mock-timestamp');
+
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: unknown[]) => mockDoc(...args),
+  getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  setDoc: (...args: unknown[]) => mockSetDoc(...args),
+  serverTimestamp: () => mockServerTimestamp(),
+}));
+
+vi.mock('../src/firebase-db', () => ({
+  db: 'mock-db',
+}));
+
+// Mock Sentry
+vi.mock('@sentry/react', () => ({
+  captureException: vi.fn(),
+}));
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: () => { store = {}; },
+  };
+})();
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+import {
+  loadLocalStreak,
+  saveLocalBackup,
+  loadFromFirestore,
+  createDebouncedSave,
+} from '../src/services/streak-persistence';
+
+const STREAK_KEY = 'streak_data';
+
+describe('loadLocalStreak', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it('returns default streak when nothing stored', () => {
+    const result = loadLocalStreak();
+    expect(result.currentStreak).toBe(0);
+    expect(result.completionDates).toEqual([]);
+  });
+
+  it('parses stored streak data', () => {
+    const data: StreakData = {
+      currentStreak: 5,
+      longestStreak: 10,
+      completionDates: ['2026-03-01', '2026-03-02'],
+      freezesUsedThisWeek: 1,
+      freezeWeekStart: '2026-02-23',
+      lastCompletionDate: '2026-03-02',
+    };
+    localStorageMock.setItem(STREAK_KEY, JSON.stringify(data));
+    const result = loadLocalStreak();
+    expect(result.currentStreak).toBe(5);
+    expect(result.completionDates).toEqual(['2026-03-01', '2026-03-02']);
+  });
+
+  it('returns default on corrupt data', () => {
+    localStorageMock.setItem(STREAK_KEY, 'not-json');
+    const result = loadLocalStreak();
+    expect(result.currentStreak).toBe(0);
+  });
+});
+
+describe('saveLocalBackup', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it('saves streak data to localStorage', () => {
+    const data: StreakData = {
+      currentStreak: 3,
+      longestStreak: 3,
+      completionDates: ['2026-03-01'],
+      freezesUsedThisWeek: 0,
+      freezeWeekStart: '2026-02-23',
+      lastCompletionDate: '2026-03-01',
+    };
+    saveLocalBackup(data);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      STREAK_KEY,
+      JSON.stringify(data),
+    );
+  });
+});
+
+describe('loadFromFirestore', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it('loads existing data from Firestore', async () => {
+    const firestoreData = {
+      currentStreak: 7,
+      longestStreak: 14,
+      completionDates: ['2026-03-01', '2026-03-02'],
+      freezesUsedThisWeek: 0,
+      freezeWeekStart: '2026-02-23',
+      lastCompletionDate: '2026-03-02',
+    };
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => firestoreData,
+    });
+
+    const result = await loadFromFirestore('user-123');
+    expect(result.currentStreak).toBe(7);
+    expect(result.completionDates).toEqual(['2026-03-01', '2026-03-02']);
+  });
+
+  it('migrates localStorage data when Firestore is empty', async () => {
+    mockGetDoc.mockResolvedValue({
+      exists: () => false,
+      data: () => null,
+    });
+
+    const localData: StreakData = {
+      currentStreak: 3,
+      longestStreak: 5,
+      completionDates: ['2026-03-01'],
+      freezesUsedThisWeek: 0,
+      freezeWeekStart: '2026-02-23',
+      lastCompletionDate: '2026-03-01',
+    };
+    localStorageMock.setItem(STREAK_KEY, JSON.stringify(localData));
+
+    const result = await loadFromFirestore('user-123');
+    expect(result.completionDates).toEqual(['2026-03-01']);
+    expect(mockSetDoc).toHaveBeenCalled();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith(STREAK_KEY);
+  });
+
+  it('returns default when both Firestore and localStorage are empty', async () => {
+    mockGetDoc.mockResolvedValue({
+      exists: () => false,
+      data: () => null,
+    });
+
+    const result = await loadFromFirestore('user-123');
+    expect(result.currentStreak).toBe(0);
+    expect(result.completionDates).toEqual([]);
+  });
+});
+
+describe('createDebouncedSave', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces saves by 500ms', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    mockSetDoc.mockResolvedValue(undefined);
+
+    const { save, cleanup } = createDebouncedSave('user-123', onSuccess, onError);
+
+    const data: StreakData = {
+      currentStreak: 1,
+      longestStreak: 1,
+      completionDates: ['2026-03-03'],
+      freezesUsedThisWeek: 0,
+      freezeWeekStart: '2026-03-02',
+      lastCompletionDate: '2026-03-03',
+    };
+
+    save(data);
+    expect(mockSetDoc).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('only saves the latest data when called multiple times', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    mockSetDoc.mockResolvedValue(undefined);
+
+    const { save, cleanup } = createDebouncedSave('user-123', onSuccess, onError);
+
+    const data1: StreakData = {
+      currentStreak: 1, longestStreak: 1, completionDates: ['2026-03-01'],
+      freezesUsedThisWeek: 0, freezeWeekStart: '2026-02-23', lastCompletionDate: '2026-03-01',
+    };
+    const data2: StreakData = {
+      currentStreak: 2, longestStreak: 2, completionDates: ['2026-03-01', '2026-03-02'],
+      freezesUsedThisWeek: 0, freezeWeekStart: '2026-02-23', lastCompletionDate: '2026-03-02',
+    };
+
+    save(data1);
+    save(data2); // should cancel first
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('cleans up pending timer', () => {
+    const { save, cleanup } = createDebouncedSave('user-123', vi.fn(), vi.fn());
+
+    save({
+      currentStreak: 1, longestStreak: 1, completionDates: [],
+      freezesUsedThisWeek: 0, freezeWeekStart: '', lastCompletionDate: null,
+    });
+
+    cleanup();
+    // If cleanup works, no Firestore call should happen
+    vi.advanceTimersByTime(1000);
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+});

--- a/tests/streak-utils.test.ts
+++ b/tests/streak-utils.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getLocalDateString,
+  previousDay,
+  getMondayOfWeek,
+  computeStreakState,
+} from '../src/utils/streak';
+
+describe('getLocalDateString', () => {
+  it('formats a specific date', () => {
+    const date = new Date(2026, 2, 3, 15, 0); // March 3, 2026
+    expect(getLocalDateString(date)).toBe('2026-03-03');
+  });
+
+  it('pads single-digit months and days', () => {
+    const date = new Date(2026, 0, 5, 12, 0); // Jan 5, 2026
+    expect(getLocalDateString(date)).toBe('2026-01-05');
+  });
+});
+
+describe('previousDay', () => {
+  it('subtracts one day', () => {
+    expect(previousDay('2026-03-03')).toBe('2026-03-02');
+  });
+
+  it('crosses month boundary', () => {
+    expect(previousDay('2026-03-01')).toBe('2026-02-28');
+  });
+
+  it('crosses year boundary', () => {
+    expect(previousDay('2026-01-01')).toBe('2025-12-31');
+  });
+
+  it('handles leap year', () => {
+    expect(previousDay('2024-03-01')).toBe('2024-02-29');
+  });
+});
+
+describe('getMondayOfWeek', () => {
+  it('returns Monday for a Monday', () => {
+    // 2026-03-02 is a Monday
+    expect(getMondayOfWeek('2026-03-02')).toBe('2026-03-02');
+  });
+
+  it('returns Monday for a Wednesday', () => {
+    // 2026-03-04 is a Wednesday
+    expect(getMondayOfWeek('2026-03-04')).toBe('2026-03-02');
+  });
+
+  it('returns Monday for a Sunday', () => {
+    // 2026-03-08 is a Sunday
+    expect(getMondayOfWeek('2026-03-08')).toBe('2026-03-02');
+  });
+
+  it('returns Monday for a Saturday', () => {
+    // 2026-03-07 is a Saturday
+    expect(getMondayOfWeek('2026-03-07')).toBe('2026-03-02');
+  });
+
+  it('crosses month boundary', () => {
+    // 2026-03-01 is a Sunday, its Monday is Feb 23
+    expect(getMondayOfWeek('2026-03-01')).toBe('2026-02-23');
+  });
+});
+
+describe('computeStreakState', () => {
+  const TODAY = '2026-03-03'; // Tuesday
+
+  it('returns 0 streak with no completion dates', () => {
+    const result = computeStreakState([], 0, TODAY);
+    expect(result.currentStreak).toBe(0);
+    expect(result.completedToday).toBe(false);
+    expect(result.freezesUsedThisWeek).toBe(0);
+  });
+
+  it('returns 1 streak if only today is completed', () => {
+    const result = computeStreakState([TODAY], 0, TODAY);
+    expect(result.currentStreak).toBe(1);
+    expect(result.completedToday).toBe(true);
+  });
+
+  it('counts consecutive days', () => {
+    const dates = ['2026-03-01', '2026-03-02', '2026-03-03'];
+    const result = computeStreakState(dates, 0, TODAY);
+    expect(result.currentStreak).toBe(3);
+    expect(result.completedToday).toBe(true);
+  });
+
+  it('breaks streak on gap in previous week without freeze', () => {
+    // Gap on 2026-02-28 (Saturday) — different week from today (Mon Mar 2)
+    // Today is Tue Mar 3, so current week starts Mon Mar 2
+    // Feb 28 is Saturday, its Monday is Feb 23 — different week, no freeze
+    const dates = ['2026-02-27', '2026-03-01', '2026-03-02', '2026-03-03'];
+    const result = computeStreakState(dates, 0, TODAY);
+    // Walking back: Mar 2 (yes, streak=1), Mar 1 (yes, streak=2)
+    // Feb 28 is NOT in set. Feb 28's Monday = Feb 23 ≠ Mar 2 (current week). No freeze. Stop.
+    // Plus today: streak = 3
+    expect(result.currentStreak).toBe(3); // Mar 3 + Mar 2 + Mar 1
+  });
+
+  it('uses freeze for gap within current week', () => {
+    // Today is 2026-03-03 (Tuesday), week starts Mar 2 (Monday)
+    // Mar 2 is NOT in dates — gap within current week, consume 1 freeze
+    // Mar 1 is Sunday — different week (Feb 23), so stop
+    const dates = ['2026-03-03'];
+    const result = computeStreakState(dates, 0, TODAY);
+    // Walk back: Mar 2 gap, same week (Mar 2), freeze #1. Mar 1 gap, week Feb 23, stop.
+    expect(result.currentStreak).toBe(1); // just today
+    expect(result.freezesUsedThisWeek).toBe(1);
+  });
+
+  it('uses up to 2 freezes within the same week', () => {
+    // Today is 2026-03-05 (Thursday), week starts Mar 2
+    const thursday = '2026-03-05';
+    // No completions on Mar 4 (Wed) or Mar 3 (Tue) — both same week
+    // Mar 2 (Mon) is completed
+    const dates = ['2026-03-02', '2026-03-05'];
+    const result = computeStreakState(dates, 0, thursday);
+    // Walk back: Mar 4 gap (same week, freeze #1), Mar 3 gap (same week, freeze #2), Mar 2 (yes, streak=1)
+    // Plus today: streak = 2
+    expect(result.currentStreak).toBe(2);
+    expect(result.freezesUsedThisWeek).toBe(2);
+  });
+
+  it('breaks streak when 3 gaps in same week (only 2 freezes)', () => {
+    // Today is 2026-03-06 (Friday), week starts Mar 2
+    const friday = '2026-03-06';
+    // No completions on Mar 5, 4, 3 — 3 gaps in same week, only 2 freezes
+    const dates = ['2026-03-02', '2026-03-06'];
+    const result = computeStreakState(dates, 0, friday);
+    // Walk back: Mar 5 gap (freeze #1), Mar 4 gap (freeze #2), Mar 3 gap (no freeze), stop
+    expect(result.currentStreak).toBe(1); // just today
+    expect(result.freezesUsedThisWeek).toBe(2);
+  });
+
+  it('tracks longest streak', () => {
+    const dates = ['2026-03-02', '2026-03-03'];
+    const result = computeStreakState(dates, 10, TODAY);
+    expect(result.currentStreak).toBe(2);
+    expect(result.longestStreak).toBe(10); // stored was higher
+  });
+
+  it('updates longest streak when current exceeds stored', () => {
+    const dates = ['2026-03-01', '2026-03-02', '2026-03-03'];
+    const result = computeStreakState(dates, 2, TODAY);
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(3);
+  });
+
+  it('handles today not completed but yesterday was', () => {
+    const dates = ['2026-03-02'];
+    const result = computeStreakState(dates, 0, TODAY);
+    // Walk back: Mar 2 (yes, streak=1), Mar 1 gap (week Feb 23, diff week, stop)
+    // Today not completed: streak stays 1
+    expect(result.currentStreak).toBe(1);
+    expect(result.completedToday).toBe(false);
+  });
+
+  it('returns freezeWeekStart as Monday of current week', () => {
+    const result = computeStreakState([], 0, TODAY);
+    expect(result.freezeWeekStart).toBe('2026-03-02');
+  });
+
+  it('handles empty dates with stored longest', () => {
+    const result = computeStreakState([], 5, TODAY);
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it('does not count duplicates twice', () => {
+    const dates = ['2026-03-02', '2026-03-02', '2026-03-03'];
+    const result = computeStreakState(dates, 0, TODAY);
+    expect(result.currentStreak).toBe(2);
+  });
+});

--- a/tests/streak-utils.test.ts
+++ b/tests/streak-utils.test.ts
@@ -172,4 +172,12 @@ describe('computeStreakState', () => {
     const result = computeStreakState(dates, 0, TODAY);
     expect(result.currentStreak).toBe(2);
   });
+
+  it('terminates with future-only dates (regression: unbounded loop)', () => {
+    // All dates are in the future — loop should terminate, not hang
+    const futureDates = ['2026-04-01', '2026-04-02'];
+    const result = computeStreakState(futureDates, 0, TODAY);
+    expect(result.currentStreak).toBe(0);
+    expect(result.completedToday).toBe(false);
+  });
 });

--- a/tests/use-streak.test.tsx
+++ b/tests/use-streak.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock streak persistence
+const mockLoadFromFirestore = vi.fn();
+const mockCreateDebouncedSave = vi.fn();
+const mockLoadLocalStreak = vi.fn();
+
+vi.mock('../src/services/streak-persistence', () => ({
+  loadFromFirestore: (...args: unknown[]) => mockLoadFromFirestore(...args),
+  createDebouncedSave: (...args: unknown[]) => mockCreateDebouncedSave(...args),
+  loadLocalStreak: () => mockLoadLocalStreak(),
+}));
+
+// Mock streak utils — keep real implementation but allow controlling getLocalDateString
+vi.mock('../src/utils/streak', async () => {
+  const actual = await vi.importActual('../src/utils/streak');
+  return {
+    ...actual,
+    getLocalDateString: vi.fn(() => '2026-03-03'),
+  };
+});
+
+import { useStreak } from '../src/hooks/useStreak';
+
+describe('useStreak', () => {
+  const mockSave = vi.fn();
+  const mockCleanup = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateDebouncedSave.mockReturnValue({ save: mockSave, cleanup: mockCleanup });
+    mockLoadFromFirestore.mockResolvedValue({
+      currentStreak: 0,
+      longestStreak: 0,
+      completionDates: [],
+      freezesUsedThisWeek: 0,
+      freezeWeekStart: '',
+      lastCompletionDate: null,
+    });
+    mockLoadLocalStreak.mockReturnValue({
+      currentStreak: 0,
+      longestStreak: 0,
+      completionDates: [],
+      freezesUsedThisWeek: 0,
+      freezeWeekStart: '',
+      lastCompletionDate: null,
+    });
+  });
+
+  it('initializes with zero streak', () => {
+    const { result } = renderHook(() => useStreak(null));
+    expect(result.current.currentStreak).toBe(0);
+    expect(result.current.completedToday).toBe(false);
+    expect(result.current.freezesRemaining).toBe(2);
+  });
+
+  it('loads from Firestore when userId is provided', async () => {
+    mockLoadFromFirestore.mockResolvedValue({
+      currentStreak: 5,
+      longestStreak: 10,
+      completionDates: ['2026-03-02', '2026-03-03'],
+      freezesUsedThisWeek: 0,
+      freezeWeekStart: '2026-03-02',
+      lastCompletionDate: '2026-03-03',
+    });
+
+    const { result } = renderHook(() => useStreak('user-123'));
+
+    // Wait for async load
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(result.current.completedToday).toBe(true);
+    expect(result.current.loaded).toBe(true);
+  });
+
+  it('records completion idempotently', async () => {
+    const { result } = renderHook(() => useStreak('user-123'));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    // Record completion
+    act(() => {
+      result.current.recordCompletion();
+    });
+
+    expect(result.current.completedToday).toBe(true);
+    expect(result.current.currentStreak).toBe(1);
+    expect(mockSave).toHaveBeenCalledTimes(1);
+
+    // Record again — should be idempotent (no extra save)
+    act(() => {
+      result.current.recordCompletion();
+    });
+
+    expect(mockSave).toHaveBeenCalledTimes(1); // still 1
+  });
+
+  it('falls back to localStorage when Firestore fails', async () => {
+    mockLoadFromFirestore.mockRejectedValue(new Error('Network error'));
+    mockLoadLocalStreak.mockReturnValue({
+      currentStreak: 2,
+      longestStreak: 5,
+      completionDates: ['2026-03-02'],
+      freezesUsedThisWeek: 0,
+      freezeWeekStart: '2026-03-02',
+      lastCompletionDate: '2026-03-02',
+    });
+
+    const { result } = renderHook(() => useStreak('user-123'));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(result.current.loaded).toBe(true);
+    // Should have loaded from localStorage — recomputed: Mar 2 only
+    expect(result.current.currentStreak).toBe(1);
+  });
+
+  it('cleans up saver on unmount', () => {
+    const { unmount } = renderHook(() => useStreak('user-123'));
+    unmount();
+    expect(mockCleanup).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Streaks**: Track daily engagement with a flame badge in the header. Users complete 50% of a chunk's duration (cumulative play time via delta accumulation — seeks rejected) to maintain their streak. Two automatic freezes per Mon-Sun calendar week cover missed days. Persists to Firestore `streaks/{userId}` with localStorage fallback.
- **Library fix**: Content library now refreshes after navigating back to the input view (was stale until page reload). Grid replaced with two quick-access buttons for the latest cached video and text.

### New files
| File | Description |
|------|-------------|
| `src/utils/streak.ts` | Pure date helpers + `computeStreakState` |
| `src/services/streak-persistence.ts` | Firestore + localStorage (follows deck-persistence pattern) |
| `src/hooks/useStreak.ts` | Load, compute, `recordCompletion` |
| `src/hooks/useCompletionDetector.ts` | Delta-based 50% play time detection |
| `src/components/StreakBadge.tsx` | Flame icon + count + freeze dots |
| 5 test files | 56 new tests covering all streak modules |

### Modified files
| File | Change |
|------|--------|
| `src/types/index.ts` | Added `StreakData` interface |
| `src/App.tsx` | Wired hooks, wrapped `onTimeUpdate`, renders badge, `refreshLibrary()` |
| `src/components/Library.tsx` | Two buttons (cached video/text) instead of grid |
| `firestore.rules` | Added `streaks/{userId}` rules |

## Test plan

- [ ] Play a chunk past 50% → streak badge turns orange, shows "1"
- [ ] Seek past 50% without playing → streak does NOT trigger
- [ ] Play 30%, pause, play 25% more → streak triggers at cumulative 50%
- [ ] Navigate away, come back → streak persists (Firestore)
- [ ] Analyze new content, return to input → library buttons update
- [ ] `npx vitest run` → 447 tests pass
- [ ] `npx tsc --noEmit` → no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)